### PR TITLE
Update WG READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ This is the starting point for becoming a contributor - improving docs, improvin
 
 ## Community Meeting
 
-We have PUBLIC and RECORDED [bi-weekly community meetings](https://zoom.us/j/986657835) every Thursday at 11am US Pacific Time.
+We have [PUBLIC](https://zoom.us/j/986657835) and [RECORDED](https://www.youtube.com/channel/UC-zVlo1F3mUbExQ96fABWcQ) bi-weekly community meetings every Thursday at 11am US Pacific Time.
 
 Map that to your local time with this [timezone table](https://www.google.com/search?q=1100+am+in+pst).
 

--- a/api-management/readme.md
+++ b/api-management/readme.md
@@ -1,0 +1,16 @@
+# Description
+
+Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged. It was popularised in the 1960s with the release of Letraset sheets containing Lorem Ipsum passages, and more recently with desktop publishing software like Aldus PageMaker including versions of Lorem Ipsum.
+
+## Meetings
+
+## Leads
+* [Wencheng Lu](https://github.com/wenchenglu), Google
+* [Jason Allor](https://github.com/ayj), Google
+* [Tony Ffrench](https://github.com/tonyffrench), IBM
+
+## Contact
+* [Mailing list](https://groups.google.com/forum/#!forum/kubernetes-sig-apps)
+
+## Goals
+*

--- a/core/readme.md
+++ b/core/readme.md
@@ -8,7 +8,11 @@ Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem
 Meeting notes and Agenda can be found [here](https://docs.google.com/document/d/1LZLBGW2wRDwAfdBNHJjFfk9CFoyZPcIYGWU7R1PQ3ng/edit#).
 
 ## Leads
-* [Joe Bloggs](https://github.com/jbloggs), Google
+* [Sven Mawson](https://github.com/smawson), Google
+* [Louis Ryan](https://github.com/louiscryan), Google
+* [Martin Taillefer](https://github.com/geeknoid), Google
+* [Shriram Rajagopalan](https://github.com/rshriram), IBM
+* [Dan Berg](https://github.com/dcberg) (IBM)
 
 ## Contact
 * [Mailing list](https://groups.google.com/forum/#!forum/kubernetes-sig-apps)

--- a/environments/readme.md
+++ b/environments/readme.md
@@ -3,12 +3,11 @@
 Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged. It was popularised in the 1960s with the release of Letraset sheets containing Lorem Ipsum passages, and more recently with desktop publishing software like Aldus PageMaker including versions of Lorem Ipsum.
 
 ## Meetings
-* [Mondays at 16:00 UTC](https://zoom.us/j/4526666954) (weekly). [Convert to your timezone](http://www.thetimezoneconverter.com/?t=16:00&tz=UTC).
-
-Meeting notes and Agenda can be found [here](https://docs.google.com/document/d/1LZLBGW2wRDwAfdBNHJjFfk9CFoyZPcIYGWU7R1PQ3ng/edit#).
 
 ## Leads
-* [Joe Bloggs](https://github.com/jbloggs), Google
+* [Costin Manolache](https://github.com/costinm), Google
+* [Laurent Demailly](https://github.com/ldemailly), Google
+* Jose Ortiz, IBM
 
 ## Contact
 * [Mailing list](https://groups.google.com/forum/#!forum/kubernetes-sig-apps)

--- a/integrations/readme.md
+++ b/integrations/readme.md
@@ -11,8 +11,8 @@ and the Mixer client libraries.
 
 ## Leads
 
-* Martin Taillefer (Google)
-* Todd Kaplinger (IBM)
+* [Martin Taillefer](https://github.com/geeknoid) (Google)
+* [Todd Kaplinger](https://github.com/todkap) (IBM)
 
 ## Contact
 

--- a/networking/readme.md
+++ b/networking/readme.md
@@ -3,12 +3,12 @@
 Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged. It was popularised in the 1960s with the release of Letraset sheets containing Lorem Ipsum passages, and more recently with desktop publishing software like Aldus PageMaker including versions of Lorem Ipsum.
 
 ## Meetings
-* [Mondays at 16:00 UTC](https://zoom.us/j/4526666954) (weekly). [Convert to your timezone](http://www.thetimezoneconverter.com/?t=16:00&tz=UTC).
-
-Meeting notes and Agenda can be found [here](https://docs.google.com/document/d/1LZLBGW2wRDwAfdBNHJjFfk9CFoyZPcIYGWU7R1PQ3ng/edit#).
 
 ## Leads
-* [Joe Bloggs](https://github.com/jbloggs), Google
+* [Andra Cismaru](https://github.com/andraxylia), Google
+* [Kuat Yessenov](https://github.com/kyessenov), Google
+* [Shriram Rajagopalan](https://github.com/rshriram), IBM
+* [Christopher Luciano](https://github.com/cmluciano), IBM
 
 ## Contact
 * [Mailing list](https://groups.google.com/forum/#!forum/kubernetes-sig-apps)

--- a/security/readme.md
+++ b/security/readme.md
@@ -3,12 +3,11 @@
 Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged. It was popularised in the 1960s with the release of Letraset sheets containing Lorem Ipsum passages, and more recently with desktop publishing software like Aldus PageMaker including versions of Lorem Ipsum.
 
 ## Meetings
-* [Mondays at 16:00 UTC](https://zoom.us/j/4526666954) (weekly). [Convert to your timezone](http://www.thetimezoneconverter.com/?t=16:00&tz=UTC).
-
-Meeting notes and Agenda can be found [here](https://docs.google.com/document/d/1LZLBGW2wRDwAfdBNHJjFfk9CFoyZPcIYGWU7R1PQ3ng/edit#).
 
 ## Leads
-* [Joe Bloggs](https://github.com/jbloggs), Google
+* [Wencheng Lu](https://github.com/wenchenglu), Google
+* [Etai Lev-Ran](https://github.com/elevran), IBM
+* [Michael Elder](https://github.com/mdelder), IBM
 
 ## Contact
 * [Mailing list](https://groups.google.com/forum/#!forum/kubernetes-sig-apps)


### PR DESCRIPTION
Add links to all of the leads per WG (couldn't find Jose's GH profile). Remove mentions of meetings that don't actually exist.

W.r.t. ordering in the leads list, I used the order in the top level README. We could do it alphabetically too.