### PR TITLE
link to correct label for help wanted issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ and read some [design docs](./CONTRIBUTING.md#design-documents).
 If you're looking for something to do to get your feet wet working on Istio, look for GitHub issues
 marked with the Help Wanted label:
 
-- [Primary Istio repo](https://github.com/istio/istio/issues?q=is%3Aopen+is%3Aissue+label%3A%22help+wanted%22)
+- [Primary Istio repo](https://github.com/istio/istio/issues?q=is%3Aopen+is%3Aissue+label%3A%22community%2Fhelp+wanted%22)
 - [Documentation repo](https://github.com/istio/istio.github.io/issues?q=is%3Aopen+is%3Aissue+label%3A%22help+wanted%22)
 
 Of course, even if there's not an issue opened for it, we can always use more


### PR DESCRIPTION
The "help wanted" label does not exist in the istio repo, just "community/help wanted", so the previous link was showing 0 issues.