### PR TITLE
Removes trailing spaces.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -62,7 +62,7 @@ Just open the template and select "Make Copy" from the File menu in order to boo
 
 In order to contribute a feature to Istio you'll need to go through the following steps:
 
-- Discuss your idea with the appropriate [working groups](WORKING-GROUPS.md) on the working 
+- Discuss your idea with the appropriate [working groups](WORKING-GROUPS.md) on the working
 group's mailing list.
 
 - Once there is general agreement that the feature is useful, create a GitHub issue to track the discussion. The issue should include information
@@ -72,7 +72,7 @@ implementation in the issue.
 - If the feature is substantial enough:
 
   - Working group leads will ask for a design document as outlined in the previous section.
-  Create the design document and add a link to it in the GitHub issue. Don't forget to send a note to the 
+  Create the design document and add a link to it in the GitHub issue. Don't forget to send a note to the
   working group to let everyone know your document is ready for review.
 
   - Depending of the breath of the design and how contentious it is, the working group leads may decide
@@ -99,7 +99,7 @@ exact code change can help focus discussions, so the choice is up to you.
 
 ## Setting up to contribute to Istio
 
-Check out this [README](https://github.com/istio/istio/blob/master/README.md) to learn about 
+Check out this [README](https://github.com/istio/istio/blob/master/README.md) to learn about
 the Istio source base and setting up your [development environment](https://github.com/istio/istio/wiki/Dev-Guide).
 
 ## Pull requests

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ and aggregate telemetry data. Istio's control plane provides an abstraction
 layer over the underlying cluster management platform, such as Kubernetes,
 Mesos, etc.
 
-Visit [istio.io](https://istio.io) for in-depth information about using Istio.     
+Visit [istio.io](https://istio.io) for in-depth information about using Istio.
 
 ## Istio authors
 
@@ -39,7 +39,7 @@ by teams from Google and IBM, in partnership with the Envoy team at Lyft.
 
 ## Community meeting
 
-We have [PUBLIC](https://zoom.us/j/986657835) and [RECORDED](https://www.youtube.com/channel/UC-zVlo1F3mUbExQ96fABWcQ) bi-weekly community meetings every other Thursday at 11am US Pacific Time. Meeting agendas and notes can be accessed in the [working doc](http://bit.ly/istiocommunitymeet). 
+We have [PUBLIC](https://zoom.us/j/986657835) and [RECORDED](https://www.youtube.com/channel/UC-zVlo1F3mUbExQ96fABWcQ) bi-weekly community meetings every other Thursday at 11am US Pacific Time. Meeting agendas and notes can be accessed in the [working doc](http://bit.ly/istiocommunitymeet).
 
 Map that to your local time with this [timezone table](https://www.google.com/search?q=1100+am+in+pst).
 

--- a/ROLES.md
+++ b/ROLES.md
@@ -22,7 +22,7 @@ necessary to join or stay in a given role, and the concrete manifestation of the
     <td>Requirements</td>
     <td>Privileges</td>
   </tr>
-  
+
   <tr>
     <td><a href="#collaborator">Collaborator</a></td>
     <td>Casual contributor to the project</td>
@@ -33,7 +33,7 @@ necessary to join or stay in a given role, and the concrete manifestation of the
         <p>Read and commenting permission on the Istio Team drive</p>
     </td>
   </tr>
-  
+
   <tr>
     <td><a href="#member">Member</a></td>
     <td>Regular active contributor in the community</td>
@@ -47,14 +47,14 @@ necessary to join or stay in a given role, and the concrete manifestation of the
         <p>Edit permission on the Istio Team drive</p>
     </td>
   </tr>
-  
+
   <tr>
     <td><a href="#approver">Approver</a></td>
     <td>Approve contributions from other members</td>
     <td>Highly experienced and active reviewer and contributor to an area</td>
     <td>‘approver’ entry in one or more OWNERS file in GitHub</td>
   </tr>
-  
+
   <tr>
     <td><a href="#lead">Lead</a></td>
     <td>
@@ -65,7 +65,7 @@ necessary to join or stay in a given role, and the concrete manifestation of the
     <td>Sponsored by the technical oversight committee as documented <a href="./WORKING-GROUP-PROCESSES.md">here</a></td>
     <td>Write permissions on one or more repos, allowing issues to be manipulated.</td>
   </tr>
-  
+
   <tr>
     <td><a href="#administrator">Administrator</a></td>
     <td>Manage & control permissions</td>
@@ -78,7 +78,7 @@ necessary to join or stay in a given role, and the concrete manifestation of the
         <p>Admin privilege to the Istio email lists.</p>
     </td>
   </tr>
-  
+
   <tr>
     <td><a href="#vendor">Vendor</a></td>
     <td>Contribute extensions to the Istio project</td>

--- a/WORKING-GROUP-PROCESSES.md
+++ b/WORKING-GROUP-PROCESSES.md
@@ -57,7 +57,7 @@ Once approval has been granted by the technical oversight committee to form a wo
 steps to establish the working group:
 
 * **Create a Google Drive Folder**. Create a folder to hold your working group documents within this parent
-[folder](https://drive.google.com/corp/drive/u/0/folders/0B7huSKYaiUN5LVdBeElXUGt3UGs). Call your folder "GROUP_NAME". 
+[folder](https://drive.google.com/corp/drive/u/0/folders/0B7huSKYaiUN5LVdBeElXUGt3UGs). Call your folder "GROUP_NAME".
 
 * **Create a Meeting Notes Document**. Create a blank document in the above folder and call it "GROUP_NAME Group Meeting Notes".
 


### PR DESCRIPTION
Removes trailing spaces. In future, might consider running some lint tool such as [markdownlint](https://github.com/markdownlint/markdownlint) in CI. 

Open for contribution if team like the idea and if they have any markdown conventions. 