### PR TITLE
Add sdake to environment working group leads

### DIFF
--- a/WORKING-GROUPS.md
+++ b/WORKING-GROUPS.md
@@ -75,6 +75,7 @@ Hot Topics Wiki | [Hot Topics Wiki](https://github.com/istio/istio/wiki/Environm
 &nbsp; | Leads | Company | Profile
 ---|---|---|---
 &nbsp; | Costin Manolache | Google | [costinm](https://github.com/costinm)
+<img width="30px" src="https://avatars0.githubusercontent.com/u/755849?s=400&v=4"> | Steven Dake | Cisco Systems | [sdake](https://github.com/sdake)
 
 ## Networking
 


### PR DESCRIPTION
During the October 12th, 2018 TOC meeting, working group leads
were reviewed.  Costin had asked me via slack if I was interested
in the role of wg lead.  I had a conflict at the scheduled TOC
meeting time and the notes are a little dry as to decisions.  I
can't tell if this nominaition was approved from the notes.

I've submitted this PR to add myself as a co-lead to determine if
the nomination was approved.

Cheers
-steve