### PR TITLE
Typo fixed: Commutity -> Community

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Other Documents
 - [Working Groups](WORKING-GROUPS.md) - describes our various working groups
 - [Working Group Processes](WORKING-GROUP-PROCESSES.md) - describes how working groups operate
 - [Technical Oversight Committee](TECH-OVERSIGHT-COMMITTEE.md) - describes our technical oversight committee
-- [Commutity Roles](ROLES.md) - describes the roles individuals can assume within the Istio community
+- [Community Roles](ROLES.md) - describes the roles individuals can assume within the Istio community
 - [Reviewing and Merging Pull Requests for Istio](REVIEWING.md) - how we manage pull requests
 - [Onboarding Technologies to Istio](ONBOARDING-TECH-TO-ISTIO.md) - how we work to onboard new technologies to the Istio project
 - [Feature Lifecycle](FEATURE-LIFECYCLE.md) - requirements for features to be labeled Alpha, Beta or Stable


### PR DESCRIPTION
Fixs typo "Commutity" to "Community" in [README.md](https://github.com/istio/community/compare/master...JoeWrightss:patch-1#diff-04c6e90faac2675aa89e2176d2eec7d8)