### PR TITLE
Quoting title for early disclosure request

### DIFF
--- a/.github/ISSUE_TEMPLATE/early-disclosure-request.md
+++ b/.github/ISSUE_TEMPLATE/early-disclosure-request.md
@@ -1,7 +1,7 @@
 ---
 name: Early Security Vulnerability Disclosure Membership Request
 about: Request membership in Istio's early vulnerability disclosure program.
-title: REQUEST: New Security Vulnerability Disclosure
+title: 'REQUEST: New Security Vulnerability Disclosure'
 ---
 
 As described in [Security Vulnerabilities](/about/security-vulnerabilities/), Istio maintains a mailing


### PR DESCRIPTION
The early disclosure issue is not being showed anymore when opening a [new issue](https://github.com/istio/community/issues/new/choose).
Probably, it is because of the missing quotes, as the Membership request issue is working properly. 