### PR TITLE
Updated link to profile of prow owner

### DIFF
--- a/ADMINS-FOR-ISTIO.md
+++ b/ADMINS-FOR-ISTIO.md
@@ -22,4 +22,4 @@ access.
 | [Community Event Calendar](https://calendar.google.com/calendar/embed?src=i10ogf58krfbrsjai5qi16g4do%40group.calendar.google.com&ctz=America%2FLos_Angeles) | [oaktowner](https://github.com/oaktowner)
 | [CircleCi](https://circleci.com/gh/istio) | [rshriram](https://github.com/rshriram), [linsun](https://github.com/linsun), [louiscryan](https://github.com/louiscryan), [smawson](https://github.com/smawson), [geeknoid](https://github.com/geeknoid)
 | [Docker Hub](https://hub.docker.com) | [rshriram](https://github.com/rshriram), [costinm](https://github.com/costinm), [mandarjog](https://github.com/mandarjog), [vadimeisenbergibm](https://github.com/vadimeisenbergibm), [frankbu](https://github.com/frankbu)
-| [Prow](https://prow.istio.io) | [utka](https://github.com/orgs/istio/people/utka)
+| [Prow](https://prow.istio.io) | [utka](https://github.com/utka)


### PR DESCRIPTION
The old link is not accessible from outside the istio org.
Linking to utka's profile now.