### PR TITLE
Update Istio community roles.

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,0 +1,54 @@
+# Istio Maintainers
+
+Here's a list of the fine folks that are the maintainers of the Istio project. They help guide the 
+technical direction, contribute to the growing code base, help take care of some of the bureaucratic duties 
+on the project, and help community members to merge their changes into the code base. Istio would not
+be what it is without these dedicated folks, so thanks!
+
+&nbsp; | Name | Company
+-------|------|--------
+<img width="30px" src="https://avatars2.githubusercontent.com/u/1090593?s=400&v=4"> | [Diana Angwar](https://github.com/icygalz) | Google 
+<img width="30px" src="https://avatars0.githubusercontent.com/u/3081257?s=400&v=4"> | [baodongli](https://github.com/baodongli) | n/a
+<img width="30px" src="https://avatars2.githubusercontent.com/u/1043139?s=400&v=4"> | [Joshua Blatt](https://github.com/duderino) | Google
+<img width="30px" src="https://avatars0.githubusercontent.com/u/2752495?s=400&v=4"> | [Frank Budinsky](https://github.com/frankbu) | IBM
+<img width="30px" src="https://avatars3.githubusercontent.com/u/10066027?s=400&v=4"> | [Rigs Caballero](https://github.com/rcaballeromx) | Google
+<img width="30px" src="https://avatars1.githubusercontent.com/u/841178?s=400&v=4"> | [Rob Cernich](https://github.com/rcernich) | Red Hat
+<img width="30px" src="https://avatars2.githubusercontent.com/u/28548492?s=400&v=4"> | [Jimmy Chen](https://github.com/JimmyCYJ) | n/a
+<img width="30px" src="https://avatars2.githubusercontent.com/u/10883640?s=400&v=4"> | [Andra Cismaru](https://github.com/andraxylia) | Google
+<img width="30px" src="https://avatars1.githubusercontent.com/u/3076511?s=400&v=4"> | [Rich Curran](https://github.com/rcurran1) | n/a
+<img width="30px" src="https://avatars1.githubusercontent.com/u/5375600?s=400&v=4"> | [Spike Curtis](https://github.com/spikecurtis) | Tigera
+<img width="30px" src="https://avatars3.githubusercontent.com/u/209726?s=400&v=4"> | [Yuchen Dai](https://github.com/silentdai) | Google
+<img width="30px" src="https://avatars0.githubusercontent.com/u/755849?s=400&v=4"> | [Steven Dake](https://github.com/sdake) | Independent
+<img width="30px" src="https://avatars0.githubusercontent.com/u/13684010?s=400&v=4"> | [Surya V Duggirala](https://github.com/suryadu) | IBM
+<img width="30px" src="https://avatars1.githubusercontent.com/u/16784982?s=400&v=4"> | [Vadim Eisenberg](https://github.com/vadimeisenbergibm) | IBM
+<img width="30px" src="https://avatars2.githubusercontent.com/u/17071139?s=400&v=4"> | [Oz Evren](https://github.com/ozevren) | Google
+<img width="30px" src="https://avatars3.githubusercontent.com/u/19473391?s=400&v=4"> | [Greg Hanson](https://github.com/GregHanson) | IBM 
+<img width="30px" src="https://avatars1.githubusercontent.com/u/623453?s=400&v=4"> | [John Howard](https://github.com/howardjohn) | Google
+<img width="30px" src="https://avatars3.githubusercontent.com/u/1661831?s=400&v=4"> | [Jianfei Hu](https://github.com/incfly) | Google
+<img width="30px" src="https://avatars0.githubusercontent.com/u/800375?s=400&v=4"> | [Mandar Jog](https://github.com/mandarjog) | Google
+<img width="30px" src="https://avatars3.githubusercontent.com/u/5739820?s=400&v=4"> | [john-a-joyce](https://github.com/john-a-joyce) | n/a
+<img width="30px" src="https://avatars0.githubusercontent.com/u/24381542?s=400&v=4"> | [Tao Li](https://github.com/wattli) | Google
+<img width="30px" src="https://avatars0.githubusercontent.com/u/32855694?s=400&v=4"> | [Quanjie Lin](https://github.com/quanjielin) | Google
+<img width="30px" src="https://avatars2.githubusercontent.com/u/4461983?s=400&v=4"> | [Guang Ya Liu](https://github.com/gyliu513) | IBM 
+<img width="30px" src="https://avatars3.githubusercontent.com/u/102881?s=400&v=4"> | [Oliver Liu](https://github.com/myidpt) | Google
+<img width="30px" src="https://avatars1.githubusercontent.com/u/84202?s=400&v=4"> | [Costin Manolache](https://github.com/costinm) | Google
+<img width="30px" src="https://avatars3.githubusercontent.com/u/6493296?s=400&v=4"> | [Nathen Mittler](https://github.com/nmittler) | Google
+<img width="30px" src="https://avatars2.githubusercontent.com/u/1722758?s=400&v=4"> | [Venil Noronha](https://github.com/venilnoronha) | VMware
+<img width="30px" src="https://avatars0.githubusercontent.com/u/30089849?s=400&v=4"> | [Martin Owstrowski](https://github.com/ostromart) | Google
+<img width="30px" src="https://avatars3.githubusercontent.com/u/8202871?s=400&v=4"> | [Shriram Rajagopalan](https://github.com/rshriram) | Tetrate
+<img width="30px" src="https://avatars2.githubusercontent.com/u/21148125?s=400&v=4"> | [Douglas Reid](https://github.com/douglas-reid) | Google
+<img width="30px" src="https://avatars0.githubusercontent.com/u/1302410?s=400&v=4"> | [Maria Skidanova](https://github.com/utka) | Google
+<img width="30px" src="https://avatars3.githubusercontent.com/u/3237651?s=400&v=4"> | [Ed Snible](https://github.com/esnible) | IBM
+<img width="30px" src="https://avatars1.githubusercontent.com/u/3328185?s=400&v=4"> | [Jimmy Song](https://github.com/rootsongjc) | Ant Financial
+<img width="30px" src="https://avatars1.githubusercontent.com/u/1588319?s=400&v=4">  | [Lin Sun](https://github.com/linsun) | IBM
+<img width="30px" src="https://avatars2.githubusercontent.com/u/3629949?s=400&v=4"> | [Tim Swanson](https://github.com/tiswanso) | Cisco
+<img width="30px" src="https://avatars3.githubusercontent.com/u/22780957?s=400&v=4"> | [Martin Taillefer](https://github.com/geeknoid) | Google
+<img width="30px" src="https://avatars0.githubusercontent.com/u/6958477?s=400&v=4"> | [Vincent](https://github.com/fleeto) | n/a
+<img width="30px" src="https://avatars2.githubusercontent.com/u/25132401?s=400&v=4"> | [Diem Vu](https://github.com/diemtvu) | Google
+<img width="30px" src="https://avatars2.githubusercontent.com/u/20001914?s=400&v=4"> | [Limin Wang](https://github.com/liminw) | Google
+<img width="30px" src="https://avatars0.githubusercontent.com/u/125759?s=400&v=4"> | [John Wendell](https://github.com/jwendell) | Red Hat
+<img width="30px" src="https://avatars1.githubusercontent.com/u/14291598?s=400&v=4"> | [Liam White](https://github.com/liamawhite) | Tetrate
+<img width="30px" src="https://avatars3.githubusercontent.com/u/28776356?s=400&v=4"> | [Fei Xu](https://github.com/fisherxu) | Huawei
+<img width="30px" src="https://avatars0.githubusercontent.com/u/13374016?s=400&v=4"> | [Zhonghu Xu](https://github.com/hzxuzhonghu) | n/a
+<img width="30px" src="https://avatars1.githubusercontent.com/u/9537734?s=400&v=4"> | [Kuat Yessenov](https://github.com/kyessenov) | Google
+<img width="30px" src="https://avatars1.githubusercontent.com/u/25786429?s=400&v=4"> | [Yutong Zhang](https://github.com/yutongz) | Google

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Other Documents
 - [Working Group Processes](WORKING-GROUP-PROCESSES.md) - describes how working groups operate
 - [Technical Oversight Committee](TECH-OVERSIGHT-COMMITTEE.md) - describes our technical oversight committee
 - [Community Roles](ROLES.md) - describes the roles individuals can assume within the Istio community
+- [Our Maintainers](MAINTAINERS.md) - lists the individuals that valiantly maintain and enhance Istio
 - [Onboarding Technologies to Istio](ONBOARDING-TECH-TO-ISTIO.md) - how we work to onboard new technologies to the Istio project
 - [Feature Lifecycle](FEATURE-LIFECYCLE.md) - requirements for features to be labeled Alpha, Beta or Stable
 - [Feature Lifecycle Checklist](FEATURE-LIFECYCLE-CHECKLIST.md) - checklist-form of requirements for features to be labeled Alpha, Beta or Stable

--- a/ROLES.md
+++ b/ROLES.md
@@ -5,19 +5,21 @@ This document describes the set of roles individuals may have within the Istio c
 * [Role summary](#role-summary)
 * [Collaborator](#collaborator)
 * [Member](#member)
-* [Approver](#approver)
+* [Maintainer](#maintainer)
 * [Lead](#lead)
 * [Administrator](#administrator)
-* [Vendor](#vendor)
+
+Transient roles
+
+* [Release manager](#release-manager)
+* [Oncall](#oncall)
 * [Sponsor](#sponsor)
 
 ## Role summary
 
 Here is the set of roles we use within the Istio community, the general responsibilities expected by individuals in each role,
 the requirements necessary to join or stay in a given role, and the concrete manifestation of the role in terms of permissions and
-privileges.  To request membership to the Istio organization, please [open an issue](https://github.com/istio/community/issues/new?template=organization-membership-request.md&title=REQUEST%3A%20New%20membership%20for%20%3Cyour-GH-handle%3E)
-and fill out the required template within the issue.
-Further, you may self-nominate to be an approver by opening an issue with a list of your key contributions.
+privileges.
 
 <table>
   <tr>
@@ -47,14 +49,18 @@ Further, you may self-nominate to be an approver by opening an issue with a list
     <td>
         <p>Member of the GitHub Istio organization</p>
         <p>Edit permission on the Istio Team drive</p>
+        <p>Write permissions on the Istio repos, allowing issues to be manipulated.</p>
     </td>
   </tr>
 
   <tr>
-    <td><a href="#approver">Approver</a></td>
+    <td><a href="#maintainer">Maintainer</a></td>
     <td>Approve contributions from other members</td>
     <td>Highly experienced and active reviewer and contributor to an area</td>
-    <td>‘approver’ entry in one or more OWNERS file in GitHub (istio/istio.io excluded)</td>
+    <td>Like a member, plus:
+        <p>Able to approve code changes in GitHub</p>
+        <p>Voting rights in the context of working group decision-making</p>
+    </td>
   </tr>
 
   <tr>
@@ -65,7 +71,7 @@ Further, you may self-nominate to be an approver by opening an issue with a list
         <p>Run their working group</p>
     </td>
     <td>Appointed by the <a href="./TECH-OVERSIGHT-COMMITTEE.md">technical oversight committee</a> as documented in <a href="./WORKING-GROUP-PROCESSES.md">Istio Working Group Processes</a></td>
-    <td>Write permissions on one or more repos, allowing issues to be manipulated.</td>
+    <td>Like a maintainer
   </tr>
 
   <tr>
@@ -73,27 +79,29 @@ Further, you may self-nominate to be an approver by opening an issue with a list
     <td>Manage & control permissions</td>
     <td>Appointed by the <a href="./TECH-OVERSIGHT-COMMITTEE.md">technical oversight committee</a></td>
     <td>
-        <p>Admin privileges on the GitHub Istio org and all its repos</p>
-        <p>Admin privileges on the Istio Slack workspace</p>
-        <p>Admin privileges on the Istio Team Drive</p>
-        <p>Admin privileges on the Google Search Console for istio.io</p>
-        <p>Admin privilege to the Istio email lists.</p>
+        <p>Admin privileges on varous Istio-related resources, as defined in <a href="./ADMINS-FOR-ISTIO.md">ADMINS-FOR-ISTIO</a></p>
     </td>
   </tr>
 
   <tr>
-    <td><a href="#vendor">Vendor</a></td>
-    <td>Contribute extensions to the Istio project</td>
-    <td>n/a</td>
-    <td>‘approver’ entry in one or more OWNERS files within the istio/contrib repo</td>
+    <td><a href="#release-manager">Release manager</a></td>
+    <td>Sheperd a release through to general availability</td>
+    <td>Appointed by the <a href="./TECH-OVERSIGHT-COMMITTEE.md">technical oversight committee</a></td>
+    <td>Admin privilege over the GitHub repos</td>
+  </tr>
+
+  <tr>
+    <td><a href="#oncall">Oncall</a></td>
+    <td>Handle a number of support functions in the project</td>
+    <td>See <a href="https://github.com/istio/istio/wiki/Oncall%20Playbook">Oncall Playbook</a> for details</td>
+    <td>Admin privilege over the GitHub repos</td>
   </tr>
 
   <tr>
     <td><a href="#sponsor">Sponsor</a></td>
-    <td>Existing member that vouches for another GitHub user that wishes to become a member of the Istio organization</td>
+    <td>Vouch for another GitHub user in order to let the user get more privilege within the project</td>
     <td>
-        <p>Must have close interactions with the prospective member - e.g. code/design/proposal review, coordinating on issues, etc.</p>
-        <p>Must be reviewers or approvers in at least 1 OWNERS file (in any repo in the Istio GitHub organization, excluding istio/istio.io).</p>
+        <p>Must have close interactions with the user</p>
     </td>
     <td>n/a</td>
   </tr>
@@ -120,12 +128,12 @@ organization, roles, policies, procedures, conventions, etc., and technical and/
 Members are continuously active contributors in the community. They can have issues and PRs assigned to them, participate in working group
 meetings, and pre-submit tests are automatically run for their PRs. Members are expected to remain active contributors to the community.
 
-All members are encouraged to help with the code review burden, although each PR must be reviewed by one or more official approvers for
-the area.
+All members are encouraged to help with the code review burden, although each PR must be reviewed by one or more official maintainers for
+the area before being accepted into the source base.
 
 ### Requirements
 
-* Has pushed at least one PR to the Istio repositories
+* Has pushed at least one PR to the Istio repositories within the last 6 months.
 
 * Subscribed to [contributors](https://discuss.istio.io/c/contributors)
 
@@ -145,36 +153,35 @@ the area.
 
 Members who frequently contribute code are expected to proactively perform code reviews for the area that they are active in.
 
-## Approver
+## Maintainer
 
-Code approvers are able to both review and approve code contributions. While code review is focused on code quality and correctness,
+Maintainers review and approve code contributions. While code review is focused on code quality and correctness,
 approval is focused on holistic acceptance of a contribution including: backwards / forwards compatibility, adhering to API and flag
-conventions, subtle performance and correctness issues, interactions with other parts of the system, etc. Approver status is scoped to a
-part of the codebase.
+conventions, subtle performance and correctness issues, interactions with other parts of the system, etc. Maintainer status is scoped to a
+part of the codebase and is reflected in a GitHub CODEOWNERS file or a prow OWNERS file.
 
 ### Requirements
 
-The following apply to the part of the codebase for which one would be an approver in an OWNERS file:
+The following apply to the part of the codebase for which one would be a maintainer:
 
 * Member for at least 3 months
 
 * Contributed at least 30 substantial PRs to the codebase
 
+* Must remain an active participant in the community by contributing
+code, performing reviews, triaging issues, etc.
+
 * Knowledgeable about the codebase
 
-* Nominated by an area lead
-
-    * With no objections from other leads
-
-    * Done through PR to update an OWNERS file
+* Sponsored by a working group lead with no objections from other leads
 
 ### Responsibilities and privileges
 
-The following apply to the part of the codebase for which one would be an approver in an OWNERS file:
+The following apply to the part of the codebase for which one would be a maintainer:
 
-* Approver status may be a precondition to accepting large code contributions
+* Maintainer status may be a precondition to accepting large code contributions
 
-* Demonstrate sound technical judgement
+* Demonstrates sound technical judgement
 
 * Responsible for project quality control via [code reviews](https://github.com/istio/istio/wiki/Reviewing-Pull-Requests)
 
@@ -186,10 +193,22 @@ The following apply to the part of the codebase for which one would be an approv
 
 * May approve code contributions for acceptance
 
+* Maintainers in an area get a stronger voice when a working group needs to make decisions.
+
+### Emeritus status
+
+If a maintainer becomes inactive in the project for an extended period of time, the individual will transition to being a
+emeritus maintainer. Emeritus maintainers lose their ability to approve code contributions, but retain their voting rights
+for up to one year. After one year, emeritus maintainers revert back to being normal members. 
+
+A maintainer becomes an emeritus maintainer if the individual hasn't contributed a PR to the project in 3 months. An emeritus 
+maintainer can regain full maintainer status by submitting 5 PRs to the project.
+
 ## Lead
 
-Working group leads, or just ‘leads’, are approvers of an entire area that have demonstrated good judgement and responsibility.
-Leads accept design proposals and approve design decisions for their area of ownership.
+Working group leads, or just ‘leads’, are maintainers of an entire area that have demonstrated good judgement and responsibility.
+Leads accept design proposals and approve design decisions for their area of ownership, triage issues, and run regular working group
+meetings.
 
 ### Requirements
 
@@ -197,9 +216,9 @@ Getting to be a lead of an existing working group:
 
 * Recognized as having expertise in the group’s subject matter
 
-* Approver for some part of the codebase for at least 3 months
+* Maintainer for some part of the codebase for at least 3 months
 
-* Member for at least 1 year (relevant as Istio ages a bit more)
+* Member for at least 1 year
 
 * Primary reviewer for 20 substantial PRs
 
@@ -211,9 +230,9 @@ Establishing the leads for a new working group:
 
 * Originally authored or contributed major functionality to an area
 
-* An approver in the top-level OWNERS file for the group’s code
+* A maintainer in the top-level OWNERS file for the group’s code
 
-* Approver for some part of the codebase for at least 3 months
+* Maintainer for some part of the codebase for at least 3 months
 
 * Member for at least 1 year
 
@@ -235,19 +254,13 @@ The following apply to the area / component for which one would be an owner.
 
 * Apply/remove/create/delete GitHub labels and milestones
 
-* Write access to repo (assign issues/PRs, add/remove labels and milestones, edit issues and PRs, edit wiki, create/delete labels and milestones)
-
-* Capable of directly applying lgtm + approve labels for any PR
-
-    * Expected to respect OWNERS files approvals and use standard procedure for merging code
-
 * Expected to work to holistically maintain the health of the project through:
 
     * Reviewing PRs
 
     * Fixing bugs
 
-    * Mentoring and guiding approvers, members, and contributors
+    * Mentoring and guiding maintainers, members, and contributors
 
 ## Administrator
 
@@ -259,36 +272,42 @@ Administrators are responsible for the bureaucratic aspects of the project.
 
 ### Responsibilities and privileges
 
-* Manage the Istio GitHub repo, including granting membership, controlling repo read/write permissions,
-and team membership
+* Manage a variety of infrastructure support for the Istio project as described in [ADMINS-FOR-ISTIO](./ADMINS-FOR-ISTIO.md)
 
-* Manage the Istio Slack workspace
+* Although admins may have the authority to override any policy and cut corners, we expect admins to generally abide
+by the overall rules of the project. For example, unless strictly necessary, admins should not approve and/or commit
+PRs they aren't entitled to if they were not admins.
 
-* Manage the Istio Google group forums
+## Release manager
 
-* Manage the Google Search Console settings for istio.io
-
-## Vendor
-
-Vendors contribute extensions to the Istio project in the form of new adapters, translated documentation, interesting examples, etc.
+Individual responsible for a particular release of the product. This person takes ownership of the
+release processes and knocks down obstacles in order to drive to a successful timely general availability of
+the release.
 
 ### Requirements
 
-* <a href="#sponsor">Sponsored</a> by a member
+* Appointed by the <a href="./TECH-OVERSIGHT-COMMITTEE.md">technical oversight committee</a>
 
 ### Responsibilities and privileges
 
-* Each vendor receives access to a subdirectory in the contrib repo, and each directory has got a distinct OWNERS file granting
-approver permissions to the vendor.
+* Get a release out the door.
+
+* Admin privilege over the GitHub repos.
+
+## Oncall
+
+Istio maintains an oncall rotation. Individuals whose turn it is to be on-call are responsible for
+handling a number of support functions in the project to ensure day-to-day operstions are running 
+smoothly.
+
+Please see the [Oncall Playbook](https://github.com/istio/istio/wiki/Oncall%20Playbook) for all the details.
 
 ## Sponsor
 
-A sponsor is a member that wishes to vouch for another user to become a member.
+A sponsor is a member that wishes to vouch for another user to support a user being assigned a specific role.
 
 ### Requirements
 
-* Sponsors must have close interactions with the prospective member - e.g. code/design/proposal review, coordinating on issues, etc.
+* Sponsors must have close interactions with the user - e.g. code/design/proposal review, coordinating on issues, etc.
 
-* Sponsors must be reviewers or approvers in at least 1 OWNERS file (in any repo in the Istio GitHub organization).
-
-* Sponsors are responsible for assessing whether a new potential member behaves in accordance to our <a href="./CONTRIBUTING.md">contribution guidelines</a>.
+* Sponsors are responsible for assessing whether a new potential user behaves in accordance to our <a href="./CONTRIBUTING.md">contribution guidelines</a>.

--- a/WORKING-GROUPS.md
+++ b/WORKING-GROUPS.md
@@ -68,7 +68,7 @@ Each working group has one or more leads which coordinate the activities of the 
 &nbsp; | [Mandar Jog](https://github.com/mandarjog) | Google | Policies and Telemetry, Performance and Scalability
 <img width="30px" src="https://avatars0.githubusercontent.com/u/24381542?s=400&v=4"> | [Tao Li](https://github.com/wattli) | Google | Security
 &nbsp; | [Costin Manolache](https://github.com/costinm) | Google | Environments
-<img width="30px" src="https://avatars3.githubusercontent.com/u/8202871?s=400&v=4"> | [Shriram Rajagopalan](https://github.com/rshriram) | VMware | Networking
+<img width="30px" src="https://avatars3.githubusercontent.com/u/8202871?s=400&v=4"> | [Shriram Rajagopalan](https://github.com/rshriram) | Tetrate | Networking
 <img width="30px" src="https://avatars2.githubusercontent.com/u/21148125?s=400&v=4"> | [Douglas Reid](https://github.com/douglas-reid) | Google | Policies and Telemetry
 <img width="30px" src="https://avatars3.githubusercontent.com/u/3237651?s=400&v=4"> | [Ed Snible](https://github.com/esnible) | IBM  | User Experience
 <img width="30px" src="https://avatars1.githubusercontent.com/u/1588319?s=400&v=4">  | [Lin Sun](https://github.com/linsun) | IBM | Test and Release


### PR DESCRIPTION
- Renamed "Approver" to "Maintainer" for better alignment with community expectations.

- Clean up and modernize content.