### PR TITLE
Add process to join the org via automation

### DIFF
--- a/.github/ISSUE_TEMPLATE/organization-membership-request.md
+++ b/.github/ISSUE_TEMPLATE/organization-membership-request.md
@@ -4,21 +4,4 @@ about: Request membership in Istio's GitHub organization.
 title: 'REQUEST: New membership for <your-GH-handle>'
 ---
 
-If you'd like to become a member of the Istio organization on GitHub, please fill out this form and submit it.
-Give us a few days to review and you should receive an invitation to join.
-
-### GitHub user id
-- List your GitHub user id
-
-### Company affiliation
-- List your company name, or indicate Individual if you're not affiliated with a company
-
-### Requirements
-- [ ] I have reviewed the [community membership guidelines](https://github.com/istio/community/blob/master/ROLES.md#member)
-- [ ] I have reviewed the [contribution guidelines](https://github.com/istio/community/blob/master/CONTRIBUTING.md)
-- [ ] I have enabled [2FA on my GitHub account](https://github.com/settings/security)
-- [ ] I have joined the [Istio discussion board](https://discuss.istio.io) and subscribed to the [Contributors](https://discuss.istio.io/c/contributors) category
-- [ ] I have joined [Istio's Slack workspace](https://istio.slack.com) (fill-out this [form](https://docs.google.com/forms/d/e/1FAIpQLSfdsupDfOWBtNVvVvXED6ULxtR4UIsYGCH_cQcRr0VcG1ZqQQ/viewform) to join)
-
-Provide a link to at least one PR that you have successfully pushed to one
-of the Istio repos
+This method of joining the organization has been deprecated. Please see [ROLES.md](ROLES.md) for steps to join.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,12 @@
+If you are joining the org, please fill out the template below:
+
+- [ ] I have reviewed the [community membership guidelines](https://github.com/istio/community/blob/master/ROLES.md#member)
+- [ ] I have reviewed the [contribution guidelines](https://github.com/istio/community/blob/master/CONTRIBUTING.md)
+- [ ] I have enabled [2FA on my GitHub account](https://github.com/settings/security)
+- [ ] I have joined the [Istio discussion board](https://discuss.istio.io) and subscribed to the [Contributors](https://discuss.istio.io/c/contributors) category
+- [ ] I have joined [Istio's Slack workspace](https://istio.slack.com) (fill-out this [form](https://docs.google.com/forms/d/e/1FAIpQLSfdsupDfOWBtNVvVvXED6ULxtR4UIsYGCH_cQcRr0VcG1ZqQQ/viewform) to join)
+
+List your company name, or indicate Individual if you're not affiliated with a company:
+
+Provide a link to at least one PR that you have successfully pushed to one
+of the Istio repos:

--- a/ROLES.md
+++ b/ROLES.md
@@ -150,6 +150,10 @@ a 180 day period, than that individual may lose membership. On-going contributio
 - Commenting on issues or pull requests
 - Closing issues or pull requests
 
+### Becoming a member
+
+If you are interested in becoming a member and meet the requirements above, you can join the organization by adding yourself to the members list under [`org/istio.yaml`](org/istio.yaml). Once that has been done, submit a Pull Request with the change and fill out the pull request template with all information requested.
+
 ### Responsibilities and privileges
 
 * Responsive to issues and PRs assigned to them

--- a/org/README.md
+++ b/org/README.md
@@ -7,3 +7,5 @@ The [`istio.yaml`](istio.yaml) file contains configuration for the Istio Github 
 To modify the org, simply change the config file and submit a PR. Once the PR is merged, the org will be updated.
 
 Changes can be tested with `make test`.
+
+To add yourself to the Org, you just need to add your name to the `members` list.


### PR DESCRIPTION
This changes the process to join the org to the new automated method.

* Replace the issue template with a message saying this method is
deprecated in case people stumble upon that. There is no documentation
pointing users there as far as I can tell
* Add a new pull request template with the same info
* Document how to join the org in the roles document