### PR TITLE
Add ayj to networking

### DIFF
--- a/org/istio.yaml
+++ b/org/istio.yaml
@@ -703,6 +703,7 @@ orgs:
             - rshriram
             members:
             - andraxylia
+            - ayj
             - bianpengyuan
             - duderino
             - GregHanson


### PR DESCRIPTION
Ownership of the galley configuration machinery is being transferred to
the top-level network maintainers as part of the Config and UX WG
merger (see [1]). In anticipation of deleting the istio config
maintainers group I'm adding myself to the general networking group to
maintain parity with the previous ownership.
    
[1] - https://docs.google.com/document/d/1B6FlFMaaqsqOaEFb-6U5VR94d3eUrc4WbqxJrdeblf8/edit#



If you are joining the org, please fill out the template below:

- [X] I have reviewed the [community membership guidelines](https://github.com/istio/community/blob/master/ROLES.md#member)
- [X] I have reviewed the [contribution guidelines](https://github.com/istio/community/blob/master/CONTRIBUTING.md)
- [X] I have enabled [2FA on my GitHub account](https://github.com/settings/security)
- [X] I have joined the [Istio discussion board](https://discuss.istio.io) and subscribed to the [Contributors](https://discuss.istio.io/c/contributors) category
- [X] I have joined [Istio's Slack workspace](https://istio.slack.com) (fill-out this [form](https://docs.google.com/forms/d/e/1FAIpQLSfdsupDfOWBtNVvVvXED6ULxtR4UIsYGCH_cQcRr0VcG1ZqQQ/viewform) to join)
