### PR TITLE
move jasonwzm to ux maintainers group

### DIFF
--- a/org/istio.yaml
+++ b/org/istio.yaml
@@ -925,6 +925,7 @@ orgs:
             - ayj
             - esnible
             - irisdingbj
+            - jasonwzm
             - liamawhite
             - nmittler
             privacy: closed


### PR DESCRIPTION
jasonwzm is a config maintainer who has been responsible for a lot of
istio's API tooling and versioning support. This type of work falls
under the charter of the merged Config+UX group. This PR is
essentially moving him from being a config maintainer to ux
maintainer. The config maintainer group will be removed when it no
longer owns any code via CODEOWNERS.
