### PR TITLE
Add sdake to the T&R maintainers.

### DIFF
--- a/org/istio.yaml
+++ b/org/istio.yaml
@@ -908,6 +908,7 @@ orgs:
             - jwendell
             - mandarjog
             - nmittler
+            - sdake
             - therealmitchconnors
             privacy: closed
             repos:


### PR DESCRIPTION
sdake is a Doc and Environment maintainer as well as a lead for the
Environemnt WG. Steve undertook a large portion of the work related to
builds using a buld container which would fall under the T&R umbrella.

Comments in PR# 20605 shows support from the other T&R WG leads as well
as Lin.

If you are joining the org, please fill out the template below:

- [ ] I have reviewed the [community membership guidelines](https://github.com/istio/community/blob/master/ROLES.md#member)
- [ ] I have reviewed the [contribution guidelines](https://github.com/istio/community/blob/master/CONTRIBUTING.md)
- [ ] I have enabled [2FA on my GitHub account](https://github.com/settings/security)
- [ ] I have joined the [Istio discussion board](https://discuss.istio.io) and subscribed to the [Contributors](https://discuss.istio.io/c/contributors) category
- [ ] I have joined [Istio's Slack workspace](https://istio.slack.com) (fill-out this [form](https://docs.google.com/forms/d/e/1FAIpQLSfdsupDfOWBtNVvVvXED6ULxtR4UIsYGCH_cQcRr0VcG1ZqQQ/viewform) to join)

List your company name, or indicate Individual if you're not affiliated with a company:

Provide a link to at least one PR that you have successfully pushed to one
of the Istio repos:
