### PR TITLE
Remove conflicting CoC

### DIFF
--- a/VALUES.md
+++ b/VALUES.md
@@ -28,9 +28,6 @@ values we hold as a team:
   - Be mindful of the terminology you are using, it may not be the same as
     someone else's and cause misunderstanding. To promote clear and precise
     communication, please define the terms you are using in context.
-  - See the
-    [CNCF Code of Conduct](https://github.com/cncf/foundation/blob/master/code-of-conduct.md)
-    which everyone must abide by.
 
 - Raising issues is great, suggesting solutions is even better
   - Think of a proposed alternative and improvement rather than just what you


### PR DESCRIPTION
In https://github.com/istio/community/commit/d43a2d617a753a2f62b03c67c4ace3802d574d0a#diff-6a3371457528722a734f3c51d9238c13R31, a different code of conduct was adopted within
the Istio community.

VALUES.md is referenced from `CONTRIBUTING.md` and `TECH-OVERSIGHT-COMMITTEE.md` which
both place the CoC first.

As such, this conflicting code of conduct may be removed.