### PR TITLE
Add Rancher to early disclosure

### DIFF
--- a/EARLY-DISCLOSURE.md
+++ b/EARLY-DISCLOSURE.md
@@ -46,6 +46,7 @@ will be removed from the early disclosure list.
 | istio-security@redhat.com | RedHat |
 | argoprod@us.ibm.com | IBM |
 | istio-security-vulnerability-notifications@google.com | Google |
+| security@rancher.com | Rancher Labs |
 
 ### Membership criteria
 


### PR DESCRIPTION
Add Rancher Labs to the early disclosure list, per earlier discussion with @duderino and team.

Istio is installed through our packaging on ~10% of the ~25k clusters for which we have data provided by (opt-in) telemetry from user's Rancher installations.