### PR TITLE
Ignore links that fail due to '429 Too Many Requests'.  

### DIFF
--- a/prow/community-lint.sh
+++ b/prow/community-lint.sh
@@ -15,4 +15,5 @@
 # limitations under the License.
 
 set -e
-awesome_bot --skip-save-result --allow-ssl --allow-timeout --allow-dupe --allow-redirect --white-list *.md
+awesome_bot --skip-save-result --allow 429 --allow-ssl --allow-timeout --allow-dupe --allow-redirect --white-list *.md
+


### PR DESCRIPTION
As the community grows and the linter issues more fetches to github, the probability that
the linter failes due to github rate limiting increases.
