### PR TITLE
Rename gorda

### DIFF
--- a/org/istio.yaml
+++ b/org/istio.yaml
@@ -15,6 +15,7 @@ orgs:
     - rshriram
     - smawson
     members:
+    - 3ks
     - aattuluri
     - abhide
     - adammil2000
@@ -73,7 +74,6 @@ orgs:
     - frankbu
     - gargnupur
     - gbaufake
-    - gorda
     - GregHanson
     - gyliu513
     - helight


### PR DESCRIPTION
Somehow they renamed their account and made "gorda" and org which blows
up the tool:
https://prow.istio.io/view/gcs/istio-prow/logs/sync-org_community_postsubmit/62

See https://github.com/istio/community/pull/285/files for the original
PR

If you are joining the org, please fill out the template below:

- [ ] I have reviewed the [community membership guidelines](https://github.com/istio/community/blob/master/ROLES.md#member)
- [ ] I have reviewed the [contribution guidelines](https://github.com/istio/community/blob/master/CONTRIBUTING.md)
- [ ] I have enabled [2FA on my GitHub account](https://github.com/settings/security)
- [ ] I have joined the [Istio discussion board](https://discuss.istio.io) and subscribed to the [Contributors](https://discuss.istio.io/c/contributors) category
- [ ] I have joined [Istio's Slack workspace](https://istio.slack.com) (fill-out this [form](https://docs.google.com/forms/d/e/1FAIpQLSfdsupDfOWBtNVvVvXED6ULxtR4UIsYGCH_cQcRr0VcG1ZqQQ/viewform) to join)

List your company name, or indicate Individual if you're not affiliated with a company:

Provide a link to at least one PR that you have successfully pushed to one
of the Istio repos:
