### PR TITLE
Updating Steering Committee charter

### DIFF
--- a/STEERING-COMMITTEE.md
+++ b/STEERING-COMMITTEE.md
@@ -19,7 +19,11 @@ and ratification of bylaws for the Steering Committee and Technical Oversight
 Committee.
 1. Establishing and enforcing principles to guide the Istio project.
 1. Fostering an environment for a healthy and happy community of developers,
+<<<<<<< HEAD
 contributors, vendors, and users.
+=======
+contributors, and users.
+>>>>>>> 0211336... Update STEERING-COMMITTEE.md
 1. Defining, evolving, and defending a
 [Code of Conduct](CONTRIBUTING.md#code-of-conduct).
 1. Advising the trademark owner on issues relating to the Istio trademark and
@@ -40,6 +44,7 @@ disputes that arise as part of the project.
 invested in the success of the Istio project to participate in business and
 non-technical decision-making.
 1.  All members should abide by the project Code of Conduct.
+<<<<<<< HEAD
 1.  There are two types of seats on the Steering Committee: Contribution Seats
 and Community Seats.
 1.  Both Contribution and Community Seats will be appointed beginning in
@@ -48,6 +53,16 @@ expire on staggered dates. After the initial term for both seats, all seats
 will have an annual term.
 1.  Contribution Seat terms expire on January 1 and Community Seat terms expire
 on July 1. If necessary, a company holding a Contribution Seat may change the
+=======
+1.  There are two types of seats on the Steering Committee: Contributor Seats
+and Community Seats.
+1.  Both Contributor and Community Seats will be appointed beginning in
+July 2020. The appointments for the Contribution and Community seat types will
+expire on staggered dates. After the initial term for both seats, all seats
+will have an annual term.
+1.  Contributor Seat terms expire on January 1 and Community Seat terms expire
+on July 1. If necessary, a company holding a Contributor Seat may change the
+>>>>>>> 0211336... Update STEERING-COMMITTEE.md
 appointed individual at any time during the term.
 1.  No Contributing Company can have more than 5 seats in total on the Steering
 Committee.
@@ -56,6 +71,7 @@ Committee.
     which are controlled by a common third party entity; and affiliate
     companies, will be treated together as a single entity, referred to as a
     Contributing Company.
+<<<<<<< HEAD
 1.  There shall be nine **Contribution Seats** allocated based on contribution
 to the project. The measurements for effort and contributions can change over
 time via the approval process of the Steering committee members. The current
@@ -63,6 +79,14 @@ measurement is based on by the number of merged pull requests on GitHub over the
 one year period prior to the Contribution Seat assignments:
     1.  The top three contributing companies to Istio are eligible for
     Contribution Seats, proportional to their contribution.
+=======
+1.  There shall be nine **Contributor Seats**. Their allocation is determined
+by the approximate effort and expenditure on the Istio project, as approximated
+by the number of merged pull requests on GitHub over the one year period prior
+to the Contributor Seat assignments:
+    1.  The top three contributing companies to Istio are eligible for
+    Contributor Seats, proportional to their contribution.
+>>>>>>> 0211336... Update STEERING-COMMITTEE.md
         1.  Each company is allocated one seat;
         1.  The remaining six seats are allocated based on percentage project
         contribution, with no Contributing Company exceeding 5 seats in total

--- a/STEERING-COMMITTEE.md
+++ b/STEERING-COMMITTEE.md
@@ -54,15 +54,15 @@ appointed individual at any time during the term.
 1. No Company can have more than 5 seats in total on the Steering Committee.
 1. There shall be nine **Contribution Seats**.  Their allocation is determined
 by the approximate effort and expenditure on the Istio project. Each year, when
-Contribution Seat terms begin, the Steering Committee will meet and vote on an
-exact formula and procedure for determining allocation for the following year.
+Contribution Seat terms begin, the Steering Committee will vote on an exact
+formula and procedure for determining allocation for the following year.
 That procedure will be published to the istio/community repository;
 modifications subsequent to the annual publication of rules shall be considered
 modifications to the Steering Committee Charter.
     1. At least three Companies shall be represented in the Contribution Seat
     membership. If the formula and procedure would not award seats to at least
     three Companies, then the third highest Company shall be awarded a seat,
-    and then the formula and procedure shall be applied to eight Seats instead
+    and then the formula and procedure shall be applied to eight seats instead
     of nine.
 1. There shall be four **Community Seats** elected by the Istio contributors
 and community, beginning in August 2020.
@@ -97,9 +97,9 @@ shall be done electronically, in a manner agreed on by the Steering Committee.
 Voting shall be open for nine calendar days, after which point it shall close.
 If at any point all the Steering Committee members have voted or abstained,
 voting shall close.
-1. The vote of an affirmative vote of 60% of the Seats shall be the decision
-of the Steering Committee. However, any changes to the Steering Committee
-Charter shall require a vote of 80% of the Seats.
+1. An affirmative vote of at least 60% of the Seats shall be the decision of
+the Steering Committee. However, any changes to the Steering Committee charter
+Charter shall require an affirmative vote of at least 80% of the Seats.
 
 ## Committee meetings
 

--- a/STEERING-COMMITTEE.md
+++ b/STEERING-COMMITTEE.md
@@ -59,11 +59,11 @@ exact formula and procedure for determining allocation for the following year.
 That procedure will be published to the istio/community repository;
 modifications subsequent to the annual publication of rules shall be considered
 modifications to the Steering Committee Charter.
-    1. The top three Companies contributing to Istio are eligible for
-    Contribution Seats, proportional to their contribution.
-        1. Each company is allocated one seat;
-        1. The remaining six seats are allocated based on project contribution,
-        with no Company exceeding 5 seats in total as outlined in this Charter.
+    1. At least three Companies shall be represented in the Contribution Seat
+    membership. If the formula and procedure would not award seats to at least
+    three Companies, then the third highest Company shall be awarded a seat,
+    and then the formula and procedure shall be applied to eight Seats instead
+    of nine.
 1. There shall be four **Community Seats** elected by the Istio contributors
 and community, beginning in August 2020.
     1. Any [project member](ROLES.md#member) can self-nominate for the
@@ -92,16 +92,14 @@ and community, beginning in August 2020.
     the Steering Committee, employees of a Company that holds Contribution
     Seats are ineligible to be elected to hold a Community Seat.
 1. A simple majority of Seats shall be sufficient to convene a meeting of the
-Steering Committee, one nominating, and the rest agreeing, over email. Meeting
-proposals shall be circulated to all Seats, and time, location, and medium shall
-be selected to be as convenient as possible. All Seats shall be given at least
-one week written notice that a meeting of the Steering Committee will be held.
-1. At all meetings of the Steering Committee convened under this charter, at
-least 60% of the Seats shall constitute a quorum for voting purposes. The vote
-of an affirmative vote of 60% of the Seats present at the time of the vote shall
-be the decision of the Steering Committee. However, any changes to the Steering
-Committee Charter shall require a vote of 80% of the Seats present at the time of
-the vote.
+Steering Committee, one nominating, and the rest agreeing, over email. Voting
+shall be done electronically, in a manner agreed on by the Steering Committee.
+Voting shall be open for nine calendar days, after which point it shall close.
+If at any point all the Steering Committee members have voted or abstained,
+voting shall close.
+1. The vote of an affirmative vote of 60% of the Seats shall be the decision
+of the Steering Committee. However, any changes to the Steering Committee
+Charter shall require a vote of 80% of the Seats.
 
 ## Committee meetings
 

--- a/STEERING-COMMITTEE.md
+++ b/STEERING-COMMITTEE.md
@@ -19,11 +19,7 @@ and ratification of bylaws for the Steering Committee and Technical Oversight
 Committee.
 1. Establishing and enforcing principles to guide the Istio project.
 1. Fostering an environment for a healthy and happy community of developers,
-<<<<<<< HEAD
 contributors, vendors, and users.
-=======
-contributors, and users.
->>>>>>> 94726b0... Update STEERING-COMMITTEE.md
 1. Defining, evolving, and defending a
 [Code of Conduct](CONTRIBUTING.md#code-of-conduct).
 1. Advising the trademark owner on issues relating to the Istio trademark and
@@ -44,7 +40,6 @@ disputes that arise as part of the project.
 invested in the success of the Istio project to participate in business and
 non-technical decision-making.
 1.  All members should abide by the project Code of Conduct.
-<<<<<<< HEAD
 1.  There are two types of seats on the Steering Committee: Contribution Seats
 and Community Seats.
 1.  Both Contribution and Community Seats will be appointed beginning in
@@ -53,16 +48,6 @@ expire on staggered dates. After the initial term for both seats, all seats
 will have an annual term.
 1.  Contribution Seat terms expire on January 1 and Community Seat terms expire
 on July 1. If necessary, a company holding a Contribution Seat may change the
-=======
-1.  There are two types of seats on the Steering Committee: Contributor Seats
-and Community Seats.
-1.  Both Contributor and Community Seats will be appointed beginning in
-July 2020. The appointments for the Contribution and Community seat types will
-expire on staggered dates. After the initial term for both seats, all seats
-will have an annual term.
-1.  Contributor Seat terms expire on January 1 and Community Seat terms expire
-on July 1. If necessary, a company holding a Contributor Seat may change the
->>>>>>> 94726b0... Update STEERING-COMMITTEE.md
 appointed individual at any time during the term.
 1.  No Contributing Company can have more than 5 seats in total on the Steering
 Committee.
@@ -71,22 +56,13 @@ Committee.
     which are controlled by a common third party entity; and affiliate
     companies, will be treated together as a single entity, referred to as a
     Contributing Company.
-<<<<<<< HEAD
-1.  There shall be nine **Contribution Seats** allocated based on contribution to
-the project. The measurements for effort and contributions can change over time
-via the approval process of the Steering committee members. The current
+1.  There shall be nine **Contribution Seats** allocated based on contribution
+to the project. The measurements for effort and contributions can change over
+time via the approval process of the Steering committee members. The current
 measurement is based on by the number of merged pull requests on GitHub over the
 one year period prior to the Contribution Seat assignments:
     1.  The top three contributing companies to Istio are eligible for
     Contribution Seats, proportional to their contribution.
-=======
-1.  There shall be nine **Contributor Seats**. Their allocation is determined
-by the approximate effort and expenditure on the Istio project, as approximated
-by the number of merged pull requests on GitHub over the one year period prior
-to the Contributor Seat assignments:
-    1.  The top three contributing companies to Istio are eligible for
-    Contributor Seats, proportional to their contribution.
->>>>>>> 94726b0... Update STEERING-COMMITTEE.md
         1.  Each company is allocated one seat;
         1.  The remaining six seats are allocated based on percentage project
         contribution, with no Contributing Company exceeding 5 seats in total
@@ -153,26 +129,17 @@ Seats in Steering are held by a company, not by the individual users. Currently 
 When the Istio project was founded, we decided that having strong corporate
 leadership was needed for the project to ensure continued velocity.
 
-<<<<<<< HEAD
 In that case, the company will select another representative to hold the seat.
 This has happened twice to date. Dan Berg filled a seat vacated by Shriram
 Rajagopalan, and Dan Ciruli filled a seat vacated by Varun Talwar.
-=======
-*What Happens If Someone Leaves the Company They Represent?*
-
-In that case, the company will select another represenative to hold the seat. This has happened twice to date. Dan Berg filled a seat vacated by Shriram Rajagopalan, and Dan Ciruli filled a seat vacated by Varun Talwar.
->>>>>>> 94726b0... Update STEERING-COMMITTEE.md
 
 *What Happens If Someone Leaves the Project or Decides to Leave Steering?*
 
 The same applies; the company will select another representative to hold the seat.
-<<<<<<< HEAD
 
 *What Happens If Someone Leaves the Project or Decides to Leave Steering?*
 
 The same applies; the company will select another representative to hold the seat.
-=======
->>>>>>> 94726b0... Update STEERING-COMMITTEE.md
 
 ## Getting in touch
 

--- a/STEERING-COMMITTEE.md
+++ b/STEERING-COMMITTEE.md
@@ -19,11 +19,7 @@ and ratification of bylaws for the Steering Committee and Technical Oversight
 Committee.
 1. Establishing and enforcing principles to guide the Istio project.
 1. Fostering an environment for a healthy and happy community of developers,
-<<<<<<< HEAD
 contributors, vendors, and users.
-=======
-contributors, and users.
->>>>>>> 0211336... Update STEERING-COMMITTEE.md
 1. Defining, evolving, and defending a
 [Code of Conduct](CONTRIBUTING.md#code-of-conduct).
 1. Advising the trademark owner on issues relating to the Istio trademark and
@@ -44,7 +40,6 @@ disputes that arise as part of the project.
 invested in the success of the Istio project to participate in business and
 non-technical decision-making.
 1.  All members should abide by the project Code of Conduct.
-<<<<<<< HEAD
 1.  There are two types of seats on the Steering Committee: Contribution Seats
 and Community Seats.
 1.  Both Contribution and Community Seats will be appointed beginning in
@@ -53,16 +48,6 @@ expire on staggered dates. After the initial term for both seats, all seats
 will have an annual term.
 1.  Contribution Seat terms expire on January 1 and Community Seat terms expire
 on July 1. If necessary, a company holding a Contribution Seat may change the
-=======
-1.  There are two types of seats on the Steering Committee: Contributor Seats
-and Community Seats.
-1.  Both Contributor and Community Seats will be appointed beginning in
-July 2020. The appointments for the Contribution and Community seat types will
-expire on staggered dates. After the initial term for both seats, all seats
-will have an annual term.
-1.  Contributor Seat terms expire on January 1 and Community Seat terms expire
-on July 1. If necessary, a company holding a Contributor Seat may change the
->>>>>>> 0211336... Update STEERING-COMMITTEE.md
 appointed individual at any time during the term.
 1.  No Contributing Company can have more than 5 seats in total on the Steering
 Committee.
@@ -71,7 +56,6 @@ Committee.
     which are controlled by a common third party entity; and affiliate
     companies, will be treated together as a single entity, referred to as a
     Contributing Company.
-<<<<<<< HEAD
 1.  There shall be nine **Contribution Seats** allocated based on contribution
 to the project. The measurements for effort and contributions can change over
 time via the approval process of the Steering committee members. The current
@@ -79,14 +63,6 @@ measurement is based on by the number of merged pull requests on GitHub over the
 one year period prior to the Contribution Seat assignments:
     1.  The top three contributing companies to Istio are eligible for
     Contribution Seats, proportional to their contribution.
-=======
-1.  There shall be nine **Contributor Seats**. Their allocation is determined
-by the approximate effort and expenditure on the Istio project, as approximated
-by the number of merged pull requests on GitHub over the one year period prior
-to the Contributor Seat assignments:
-    1.  The top three contributing companies to Istio are eligible for
-    Contributor Seats, proportional to their contribution.
->>>>>>> 0211336... Update STEERING-COMMITTEE.md
         1.  Each company is allocated one seat;
         1.  The remaining six seats are allocated based on percentage project
         contribution, with no Contributing Company exceeding 5 seats in total

--- a/STEERING-COMMITTEE.md
+++ b/STEERING-COMMITTEE.md
@@ -91,7 +91,7 @@ and community, beginning in August 2020.
     1. Because the goal of Community Seats is to increase the perspectives on
     the Steering Committee, employees of a Company that holds Contribution
     Seats are ineligible to be elected to hold a Community Seat.
-1. A simple majority of Seats shall be sufficient to convene a meeting of the
+1. A simple majority of Seats shall be sufficient to call a vote of the
 Steering Committee, one nominating, and the rest agreeing, over email. Voting
 shall be done electronically, in a manner agreed on by the Steering Committee.
 Voting shall be open for nine calendar days, after which point it shall close.

--- a/STEERING-COMMITTEE.md
+++ b/STEERING-COMMITTEE.md
@@ -40,14 +40,14 @@ disputes that arise as part of the project.
 invested in the success of the Istio project to participate in business and
 non-technical decision-making.
 1.  All members should abide by the project Code of Conduct.
-1.  There are two types of seats on the Steering Committee: Contributor Seats
+1.  There are two types of seats on the Steering Committee: Contribution Seats
 and Community Seats.
-1.  Both Contributor and Community Seats will be appointed beginning in
+1.  Both Contribution and Community Seats will be appointed beginning in
 July 2020. The appointments for the Contribution and Community seat types will
 expire on staggered dates. After the initial term for both seats, all seats
 will have an annual term.
-1.  Contributor Seat terms expire on January 1 and Community Seat terms expire
-on July 1. If necessary, a company holding a Contributor Seat may change the
+1.  Contribution Seat terms expire on January 1 and Community Seat terms expire
+on July 1. If necessary, a company holding a Contribution Seat may change the
 appointed individual at any time during the term.
 1.  No Contributing Company can have more than 5 seats in total on the Steering
 Committee.
@@ -56,13 +56,13 @@ Committee.
     which are controlled by a common third party entity; and affiliate
     companies, will be treated together as a single entity, referred to as a
     Contributing Company.
-1.  There shall be nine **Contributor Seats** allocated based on contribution to
+1.  There shall be nine **Contribution Seats** allocated based on contribution to
 the project. The measurements for effort and contributions can change over time
 via the approval process of the Steering committee members. The current
 measurement is based on by the number of merged pull requests on GitHub over the
-one year period prior to the Contributor Seat assignments::
+one year period prior to the Contribution Seat assignments:
     1.  The top three contributing companies to Istio are eligible for
-    Contributor Seats, proportional to their contribution.
+    Contribution Seats, proportional to their contribution.
         1.  Each company is allocated one seat;
         1.  The remaining six seats are allocated based on percentage project
         contribution, with no Contributing Company exceeding 5 seats in total

--- a/STEERING-COMMITTEE.md
+++ b/STEERING-COMMITTEE.md
@@ -134,7 +134,8 @@ Seats in Steering are held by a company, not by the individual users. Currently 
 
 *Why Are Seats Company Held?*
 
-The Steering Committee was created as the Istio project was in infancy, in order to tackle governance and overall project strategy. To date Istio has the bulk of contributions coming from the project founders, Google & IBM. Together it was decided that having strong corporate leadership was needed for the project to ensure continued velocity. Steering was created with 9 seats held, and with 11 being planned.
+When the Istio project was founded, we decided that having strong corporate
+leadership was needed for the project to ensure continued velocity.
 
 *What Happens If Someone Leaves the Company They Represent?*
 

--- a/STEERING-COMMITTEE.md
+++ b/STEERING-COMMITTEE.md
@@ -136,14 +136,6 @@ Seats in Steering are held by a company, not by the individual users. Currently 
 
 The Steering Committee was created as the Istio project was in infancy, in order to tackle governance and overall project strategy. To date Istio has the bulk of contributions coming from the project founders, Google & IBM. Together it was decided that having strong corporate leadership was needed for the project to ensure continued velocity. Steering was created with 9 seats held, and with 11 being planned.
 
-*How Are Steering Seats Allocated?*
-
-Allocation is based upon corporate contributions, although no final decision has been made on the exact formula. We do plan to add additional seats to Steering. Community feedback on the process and allocation formula is very welcome! We do want to ensure that those contributing to the project are properly represented. At a minimum, the membership is reviewed once a year.
-
-*Why Does Google Have The Most Seats?*
-
-This is weighted to reflect project contributions.
-
 *What Happens If Someone Leaves the Company They Represent?*
 
 In that case, the company will select another representative to hold the seat.
@@ -151,13 +143,6 @@ In that case, the company will select another representative to hold the seat.
 *What Happens If Someone Leaves the Project or Decides to Leave Steering?*
 
 The same applies; the company will select another representative to hold the seat.
-
-*Is This Steering Model Permanent?*
-
-*What Happens If Someone Leaves the Project or Decides to Leave Steering?*
-
-The same applies; the company will select another representative to hold the
-seat.
 
 ## Getting in touch
 

--- a/STEERING-COMMITTEE.md
+++ b/STEERING-COMMITTEE.md
@@ -128,9 +128,13 @@ Seats in Steering are held by a company, not by the individual users. Currently 
 When the Istio project was founded, we decided that having strong corporate
 leadership was needed for the project to ensure continued velocity.
 
-*What Happens If Someone Leaves the Company They Represent?*
+In that case, the company will select another representative to hold the seat.
+This has happened twice to date. Dan Berg filled a seat vacated by Shriram
+Rajagopalan, and Dan Ciruli filled a seat vacated by Varun Talwar.
 
-In that case, the company will select another represenative to hold the seat. This has happened twice to date. Dan Berg filled a seat vacated by Shriram Rajagopalan, and Dan Ciruli filled a seat vacated by Varun Talwar.
+*What Happens If Someone Leaves the Project or Decides to Leave Steering?*
+
+The same applies; the company will select another representative to hold the seat.
 
 *What Happens If Someone Leaves the Project or Decides to Leave Steering?*
 

--- a/STEERING-COMMITTEE.md
+++ b/STEERING-COMMITTEE.md
@@ -19,7 +19,7 @@ and ratification of bylaws for the Steering Committee and Technical Oversight
 Committee.
 1. Establishing and enforcing principles to guide the Istio project.
 1. Fostering an environment for a healthy and happy community of developers,
-contributors, and users.
+contributors, vendors, and users.
 1. Defining, evolving, and defending a
 [Code of Conduct](CONTRIBUTING.md#code-of-conduct).
 1. Advising the trademark owner on issues relating to the Istio trademark and

--- a/STEERING-COMMITTEE.md
+++ b/STEERING-COMMITTEE.md
@@ -101,7 +101,7 @@ require both a quorum and a vote of 80% of the Steering Committee Seats.
 
 ## Committee meetings
 
-The Istio Steering Committee meets weekly; currently on Tuesday mornings.
+The Istio Steering Committee meets weekly.
 Given the nature of the discussions in Steering, meetings are not currently open to the public. Questions around governance are listed as [issues in the community repo](https://github.com/istio/community/labels/steering-governance), and we invite your feedback there.
 
 ## Committee members
@@ -125,7 +125,8 @@ Seats in Steering are held by a company, not by the individual users. Currently 
 
 *Why Are Seats Company Held?*
 
-The Steering Committee was created as the Istio project was in infancy, in order to tackle governance and overall project strategy. To date Istio has the bulk of contributions coming from the project founders, Google & IBM. Together it was decided that having strong corporate leadership was needed for the project to ensure continued velocity. Steering was created with 9 seats held, and with 11 being planned.
+When the Istio project was founded, we decided that having strong corporate
+leadership was needed for the project to ensure continued velocity.
 
 *What Happens If Someone Leaves the Company They Represent?*
 

--- a/STEERING-COMMITTEE.md
+++ b/STEERING-COMMITTEE.md
@@ -1,9 +1,10 @@
 # Istio Steering Committee
 
 The Istio Steering Committee was formed to oversee the administrative aspects of the project, including governance, branding, and marketing.
-Steering was created to allow the Technical Oversight Committee to exclusively focus on the technical aspects of the project. 
+Steering was created to allow the Technical Oversight Committee to exclusively focus on the technical aspects of the project.
 
 * [Charter](#charter)
+* [Membership and Voting](#membership-and-voting)
 * [Committee meetings](#committee-meetings)
 * [Committee members](#committee-members)
 * [General questions](#general-questions)
@@ -11,17 +12,97 @@ Steering was created to allow the Technical Oversight Committee to exclusively f
 
 ## Charter
 
-1. Define, evolve, and defend the vision, values, mission, and scope of the project - to establish and maintain the soul of Istio.
-2. Define and evolve project governance structures and policies, including how contributors become committers/maintainers, approvers, reviewers, members, code of conduct, etc.
-3. Control access to, establish processes regarding, and provide a final escalation path for any Istio repository.
-4. Control and delegate access to and establish processes regarding other project resources and assets, including artifact repositories, build and test infrastructure, web sites and their domains, blogs, social-media accounts, etc.
-5. Manage the Istio brand to decide which things can be called “Istio” and how that mark can be used in relation to other efforts or vendors.
-6. Resolve any dispute from the Technical Oversight Committee.
+The Steering Committee’s responsibilities include:
+
+1. Establishing rules of governance for the Istio project, including creation
+and ratification of bylaws for the Steering Committee and Technical Oversight
+Committee.
+1. Establishing and enforcing principles to guide the Istio project.
+1. Fostering an environment for a healthy and happy community of developers,
+contributors, and users.
+1. Defining, evolving, and defending a
+[Code of Conduct](CONTRIBUTING.md#code-of-conduct).
+1. Advising the trademark owner on issues relating to the Istio trademark and
+logo.
+1. Setting marketing and advocacy direction for the project; establishing a
+publishing schedule and vetting content, encouraging and assisting in project
+community members, fostering an ecosystem of vendors, creating content for
+conferences, etc.
+1. Controlling and delegating access to, and establishing processes regarding,
+project resources/assets, including but not limited to artifact repositories,
+build and test infrastructure, web sites and their domains, blogs, and social
+media accounts.
+1. Providing neutral mediation as appropriate to try to resolve non-technical
+disputes that arise as part of the project.
+
+## Membership and voting
+1.  The Steering Committee is structured to allow companies who are most
+invested in the success of the Istio project to participate in business and
+non-technical decision-making.
+1.  All members should abide by the project Code of Conduct.
+1.  There are two types of seats on the Steering Committee: Contributor Seats
+and Community Seats.
+1.  Both Contributor and Community Seats will be appointed beginning in
+July 2020. The appointments for the Contribution and Community seat types will
+expire on staggered dates. After the initial term for both seats, all seats
+will have an annual term.
+1.  Contributor Seat terms expire on January 1 and Community Seat terms expire
+on July 1. If necessary, a company holding a Contributor Seat may change the
+appointed individual at any time during the term.
+1.  No Contributing Company can have more than 5 seats in total on the Steering
+Committee.
+    1.  Subsidiaries, an entity in which another company owns more than 50%
+    of the voting or membership interests; and related companies, companies
+    which are controlled by a common third party entity; and affiliate
+    companies, will be treated together as a single entity, referred to as a
+    Contributing Company.
+1.  There shall be nine **Contributor Seats**. Their allocation is determined
+by the approximate effort and expenditure on the Istio project, as approximated
+by the number of merged pull requests on GitHub over the one year period prior
+to the Contributor Seat assignments:
+    1.  The top three contributing companies to Istio are eligible for
+    Contributor Seats, proportional to their contribution.
+        1.  Each company is allocated one seat;
+        1.  The remaining six seats are allocated based on percentage project
+        contribution, with no Contributing Company exceeding 5 seats in total
+        as outlined in section 6.
+1.  There shall be four **Community Seats.**
+    1.  Two **Community Seats** will be elected by the Istio contributors and
+    community, beginning in July 2020.
+        1.  Any [project member](ROLES.md#member) can self-nominate for the
+        election, or nominate another project member with their consent.
+        1.  Elections use time-limited, Condorcet voting.
+        1.  The following are eligible to vote for Community Seats:
+            1.  Project [Members](ROLES.md#member) who have had a merged PR in
+            the 12 months prior to the election; and
+            1.  People who have submitted a voting exception form to the
+            Steering Committee, demonstrating contribution to the Istio project
+            that is of a non-code nature in the 12 months prior to the election,
+            and are granted a vote for the election by a simple majority vote of
+            the Steering Committee.
+        1.  Community Seats are maintained for the term by the individual, even
+        if they change their company affiliation.
+            1.  If an individual changes company affiliation mid-term in a way
+            that is incompatible with the company representation policies in
+            this Charter, the individual may keep their seat for the duration of
+            the term.
+    1.  Two Community Seats will be appointed through a vote of the Steering
+    Committee after the community election.
+        1.  These seats are intended to diversify perspectives and expertise on
+        the Committee.
+    1.  Because the goal of Community Seats is to increase the perspectives on
+    the Steering Committee, employees of a Contributing Company are ineligible
+    to be elected to hold a Community Seat.
+1.  At all meetings of the Steering Committee, at least 60% of the Seats shall
+constitute a quorum for voting purposes. The vote of an affirmative vote of 60%
+of the Seats present at the time of the vote shall be the decision of the
+Steering Committee. However, any changes to the Steering Committee Charter shall
+require both a quorum and a vote of 80% of the Steering Committee Seats.
 
 ## Committee meetings
 
-The Istio Steering Committee meets weekly; currently on Tuesday mornings. 
-Given the nature of the discussions in Steering, meetings are not currently open to the public. Questions around governance are listed as [issues in the community repo](https://github.com/istio/community/labels/steering-governance), and we invite your feedback there. 
+The Istio Steering Committee meets weekly; currently on Tuesday mornings.
+Given the nature of the discussions in Steering, meetings are not currently open to the public. Questions around governance are listed as [issues in the community repo](https://github.com/istio/community/labels/steering-governance), and we invite your feedback there.
 
 ## Committee members
 
@@ -46,29 +127,13 @@ Seats in Steering are held by a company, not by the individual users. Currently 
 
 The Steering Committee was created as the Istio project was in infancy, in order to tackle governance and overall project strategy. To date Istio has the bulk of contributions coming from the project founders, Google & IBM. Together it was decided that having strong corporate leadership was needed for the project to ensure continued velocity. Steering was created with 9 seats held, and with 11 being planned.
 
-*How Are Steering Seats Allocated?*
-
-Allocation is based upon corporate contributions, although no final decision has been made on the exact formula. We do plan to add additional seats to Steering. Community feedback on the process and allocation formula is very welcome! We do want to ensure that those contributing to the project are properly represented. At a minimum, the membership is reviewed once a year.
-
-*Why Does Google Have The Most Seats?*
-
-This is weighted to reflect project contributions.
-
 *What Happens If Someone Leaves the Company They Represent?*
 
-In that case, the company will select another representative to hold the seat. 
+In that case, the company will select another represenative to hold the seat. This has happened twice to date. Dan Berg filled a seat vacated by Shriram Rajagopalan, and Dan Ciruli filled a seat vacated by Varun Talwar.
 
 *What Happens If Someone Leaves the Project or Decides to Leave Steering?*
 
-The same applies; the company will select another representative to hold the seat. 
-
-*Is This Steering Model Permanent?*
-
-We recognize that governance of an open source project is a living document, and evolves as the community and project grows. This is the model that works for the project now. As it matures, and as the community grows, we expect that needs will change. 
-
-*How Are Things Decided By Steering?*
-
-We strive to find a path to consensus. Decisions are made in meetings when a quorum is present, and may pass with majority vote.
+The same applies; the company will select another representative to hold the seat.
 
 ## Getting in touch
 

--- a/STEERING-COMMITTEE.md
+++ b/STEERING-COMMITTEE.md
@@ -134,12 +134,25 @@ Seats in Steering are held by a company, not by the individual users. Currently 
 
 *Why Are Seats Company Held?*
 
-When the Istio project was founded, we decided that having strong corporate
-leadership was needed for the project to ensure continued velocity.
+The Steering Committee was created as the Istio project was in infancy, in order to tackle governance and overall project strategy. To date Istio has the bulk of contributions coming from the project founders, Google & IBM. Together it was decided that having strong corporate leadership was needed for the project to ensure continued velocity. Steering was created with 9 seats held, and with 11 being planned.
+
+*How Are Steering Seats Allocated?*
+
+Allocation is based upon corporate contributions, although no final decision has been made on the exact formula. We do plan to add additional seats to Steering. Community feedback on the process and allocation formula is very welcome! We do want to ensure that those contributing to the project are properly represented. At a minimum, the membership is reviewed once a year.
+
+*Why Does Google Have The Most Seats?*
+
+This is weighted to reflect project contributions.
+
+*What Happens If Someone Leaves the Company They Represent?*
+
+In that case, the company will select another representative to hold the seat.
 
 *What Happens If Someone Leaves the Project or Decides to Leave Steering?*
 
-In that case, the company will select another representative to hold the seat.
+The same applies; the company will select another representative to hold the seat.
+
+*Is This Steering Model Permanent?*
 
 *What Happens If Someone Leaves the Project or Decides to Leave Steering?*
 

--- a/STEERING-COMMITTEE.md
+++ b/STEERING-COMMITTEE.md
@@ -7,7 +7,6 @@ Steering was created to allow the Technical Oversight Committee to exclusively f
 * [Membership and Voting](#membership-and-voting)
 * [Committee meetings](#committee-meetings)
 * [Committee members](#committee-members)
-* [General questions](#general-questions)
 * [Getting in touch](#getting-in-touch)
 
 ## Charter
@@ -25,9 +24,8 @@ contributors, vendors, and users.
 1. Advising the Open Usage Commons on issues relating to the Istio trademark and
 logo, as well as related conformance programs.
 1. Setting marketing and advocacy direction for the project; establishing a
-publishing schedule and vetting content, encouraging and assisting in project
-community members, fostering an ecosystem of vendors, creating content for
-conferences, etc.
+publishing schedule and vetting content, encouraging and assisting community
+members in creating content for conferences, fostering an ecosystem of vendors.
 1. Controlling and delegating access to, and establishing processes regarding,
 project resources/assets, including but not limited to artifact repositories,
 build and test infrastructure, web sites and their domains, blogs, and social
@@ -36,68 +34,64 @@ media accounts.
 disputes that arise as part of the project.
 
 ## Membership and voting
-1.  The Steering Committee is structured to allow companies who are most
+
+1. A Company shall mean an entity which employs a member, and all other
+entities that control, are controlled by, or are under common control with that
+entity.
+1. The Steering Committee is structured to allow Companies who are most
 invested in the success of the Istio project to participate in business and
 non-technical decision-making.
-1.  All members should abide by the project
-[Code of Conduct](CONTRIBUTING.md#code-of-conduct).
-1.  There are two types of seats on the Steering Committee: Contribution Seats
+1. All members should abide by the project Code of Conduct.
+1. There are two types of seats on the Steering Committee: Contribution Seats
 and Community Seats.
-1.  Both Contributor and Community Seats will be appointed beginning in
-July 2020. The appointments for the Contribution and Community seat types will
+1. Both Contribution and Community Seats will be appointed beginning in
+August 2020. The appointments for the Contribution and Community seat types will
 expire on staggered dates. After the initial term for both seats, all seats
 will have an annual term.
-1.  Contribution Seat terms expire on January 31 and Community Seat terms expire
+1. Contribution Seat terms expire on January 31 and Community Seat terms expire
 on July 31. If necessary, a company holding a Contribution Seat may change the
 appointed individual at any time during the term.
-1.  No Contributing Company can have more than 5 seats in total on the Steering
-Committee.
-    1.  Subsidiaries, an entity in which another company owns more than 50%
-    of the voting or membership interests; and related companies, companies
-    which are controlled by a common third party entity; and affiliate
-    companies, will be treated together as a single entity, referred to as a
-    Contributing Company.
-1.  There shall be nine **Contribution Seats**.  Their allocation is determined
-by the approximate effort and expenditure on the Istio project.  Each year, the
-Steering Committee will meet and vote on an exact formula and procedure for
-determining allocation, and publish this to the istio/community repository;
+1. No Company can have more than 5 seats in total on the Steering Committee.
+1. There shall be nine **Contribution Seats**.  Their allocation is determined
+by the approximate effort and expenditure on the Istio project. Each year, when
+Contribution Seat terms begin, the Steering Committee will meet and vote on an
+exact formula and procedure for determining allocation for the following year.
+That procedure will be published to the istio/community repository;
 modifications subsequent to the annual publication of rules shall be considered
 modifications to the Steering Committee Charter.
-    1.  The top three contributing companies to Istio are eligible for
+    1. The top three Companies contributing to Istio are eligible for
     Contribution Seats, proportional to their contribution.
-        1.  Each company is allocated one seat;
-        1.  The remaining six seats are allocated based on percentage project
-        contribution, with no Contributing Company exceeding 5 seats in total
-        as outlined in section 6.
-1.  There shall be four **Community Seats.**
-    1.  Two **Community Seats** will be elected by the Istio contributors and
-    community, beginning in July 2020.
-        1.  Any [project member](ROLES.md#member) can self-nominate for the
-        election, or nominate another project member with their consent.
-        1.  Elections use time-limited, Condorcet voting.
-        1.  The following are eligible to vote for Community Seats:
-            1.  Project [Members](ROLES.md#member) who have had a merged PR in
-            the 12 months prior to the election; and
-            1.  People who have submitted a voting exception form to the
-            Steering Committee, demonstrating contribution to the Istio project
-            that is of a non-code nature in the 12 months prior to the election,
-            and are granted a vote for the election by a simple majority vote of
-            the Steering Committee.
-        1.  No Contributing Company can hold more than one Community Seat.
-        1.  Community Seats are maintained for the term by the individual, even
-        if they change their company affiliation.
-            1.  If an individual changes company affiliation mid-term in a way
-            that is incompatible with the company representation policies in
-            this Charter, the individual will be considered to have resigned
-            their seat and the first eligible runner-up from the previous
-            election will replace them for the duration of the term. If there
-            is no first runner-up eligible to serve in the as per these rules,
-            then the Steering Committee shall vote by simple majority to replace
-            the seat for the term.
-            1.  Because the goal of Community Seats is to increase the
-            perspectives on the Steering Committee, employees of a Contributing
-            Company are ineligible to be elected to hold a Community Seat.
-1.  A simple majority of Seats shall be sufficient to convene a meeting of the
+        1. Each company is allocated one seat;
+        1. The remaining six seats are allocated based on project contribution,
+        with no Company exceeding 5 seats in total as outlined in this Charter.
+1. There shall be four **Community Seats** elected by the Istio contributors
+and community, beginning in August 2020.
+    1. Any [project member](ROLES.md#member) can self-nominate for the
+    election, or nominate another project member with their consent.
+    1. Elections shall use time-limited, Condorcet voting.
+    1. The following are eligible to vote for Community Seats:
+        1. [Project members](ROLES.md#member) who have had a merged PR in
+        the 12 months prior to the election; and
+        1. People who have submitted a voting exception form to the
+        Steering Committee, demonstrating contribution to the Istio project
+        that is of a non-code nature in the 12 months prior to the election,
+        and are granted a vote for the election by a simple majority vote of
+        the Steering Committee.
+    1. No Company can hold more than one Community Seat.
+    1. Community Seats are maintained for the term by the individual, even
+    if they change their Company affiliation.
+        1. If an individual changes company affiliation mid-term in a way
+        that is incompatible with the Company representation policies in
+        this Charter, the individual will be considered to have resigned
+        their seat and the first eligible runner-up from the previous
+        election will replace them for the duration of the term. If there
+        is no first runner-up eligible to serve in the as per these rules,
+        then the Steering Committee shall vote by simple majority to replace
+        the seat for the term.
+    1. Because the goal of Community Seats is to increase the perspectives on
+    the Steering Committee, employees of a Company that holds Contribution
+    Seats are ineligible to be elected to hold a Community Seat.
+1. A simple majority of Seats shall be sufficient to convene a meeting of the
 Steering Committee, one nominating, and the rest agreeing, over email. Meeting
 proposals shall be circulated to all Seats, and time, location, and medium shall
 be selected to be as convenient as possible. All Seats shall be given at least
@@ -106,7 +100,8 @@ one week written notice that a meeting of the Steering Committee will be held.
 least 60% of the Seats shall constitute a quorum for voting purposes. The vote
 of an affirmative vote of 60% of the Seats present at the time of the vote shall
 be the decision of the Steering Committee. However, any changes to the Steering
-Committee Charter shall require a vote of 80% of the Steering Committee Seats.
+Committee Charter shall require a vote of 80% of the Seats present at the time of
+the vote.
 
 ## Committee meetings
 
@@ -114,8 +109,6 @@ The Istio Steering Committee meets weekly.
 Given the nature of the discussions in Steering, meetings are not currently open to the public. Questions around governance are listed as [issues in the community repo](https://github.com/istio/community/labels/steering-governance), and we invite your feedback there.
 
 ## Committee members
-
-Seats in Steering are held by a company, not by the individual users. Currently Steering consists of members from Google, IBM & Red Hat. These are:
 
 &nbsp; | Name | Company | Profile
 ---|---|---|---
@@ -129,21 +122,6 @@ Seats in Steering are held by a company, not by the individual users. Currently 
 <img width="30px" src="https://avatars3.githubusercontent.com/u/1934555?s=400&v=4">  | Sean Suchter | Google | [ssuchter](https://github.com/ssuchter)
 <img width="30px" src="https://avatars1.githubusercontent.com/u/1588319?s=400&v=4">  | Lin Sun | IBM | [linsun](https://github.com/linsun)
 <img width="30px" src="https://avatars1.githubusercontent.com/u/5502967?s=400&v=4">  | Ram Vennam | IBM | [rvennam](https://github.com/rvennam)
-
-## General questions
-
-*Why Are Seats Company Held?*
-
-When the Istio project was founded, we decided that having strong corporate
-leadership was needed for the project to ensure continued velocity.
-
-*What Happens If Someone Leaves the Company They Represent?*
-
-In that case, the company will select another representative to hold the seat.
-
-*What Happens If Someone Leaves the Project or Decides to Leave Steering?*
-
-The same applies; the company will select another representative to hold the seat.
 
 ## Getting in touch
 

--- a/STEERING-COMMITTEE.md
+++ b/STEERING-COMMITTEE.md
@@ -56,10 +56,11 @@ Committee.
     which are controlled by a common third party entity; and affiliate
     companies, will be treated together as a single entity, referred to as a
     Contributing Company.
-1.  There shall be nine **Contributor Seats**. Their allocation is determined
-by the approximate effort and expenditure on the Istio project, as approximated
-by the number of merged pull requests on GitHub over the one year period prior
-to the Contributor Seat assignments:
+1.  There shall be nine **Contributor Seats** allocated based on contribution to
+the project. The measurements for effort and contributions can change over time
+via the approval process of the Steering committee members. The current
+measurement is based on by the number of merged pull requests on GitHub over the
+one year period prior to the Contributor Seat assignments::
     1.  The top three contributing companies to Istio are eligible for
     Contributor Seats, proportional to their contribution.
         1.  Each company is allocated one seat;

--- a/STEERING-COMMITTEE.md
+++ b/STEERING-COMMITTEE.md
@@ -98,7 +98,7 @@ one year period prior to the Contribution Seat assignments:
 constitute a quorum for voting purposes. The vote of an affirmative vote of 60%
 of the Seats present at the time of the vote shall be the decision of the
 Steering Committee. However, any changes to the Steering Committee Charter shall
-require both a quorum and a vote of 80% of the Steering Committee Seats.
+require a vote of 80% of the Steering Committee Seats.
 
 ## Committee meetings
 

--- a/STEERING-COMMITTEE.md
+++ b/STEERING-COMMITTEE.md
@@ -22,8 +22,8 @@ Committee.
 contributors, vendors, and users.
 1. Defining, evolving, and defending a
 [Code of Conduct](CONTRIBUTING.md#code-of-conduct).
-1. Advising the trademark owner on issues relating to the Istio trademark and
-logo.
+1. Advising the Open Usage Commons on issues relating to the Istio trademark and
+logo, as well as related conformance programs.
 1. Setting marketing and advocacy direction for the project; establishing a
 publishing schedule and vetting content, encouraging and assisting in project
 community members, fostering an ecosystem of vendors, creating content for
@@ -39,15 +39,16 @@ disputes that arise as part of the project.
 1.  The Steering Committee is structured to allow companies who are most
 invested in the success of the Istio project to participate in business and
 non-technical decision-making.
-1.  All members should abide by the project Code of Conduct.
-1.  There are two types of seats on the Steering Committee: Contribution Seats
+1.  All members should abide by the project
+[Code of Conduct](CONTRIBUTING.md#code-of-conduct).
+1.  There are two types of seats on the Steering Committee: Contributor Seats
 and Community Seats.
-1.  Both Contribution and Community Seats will be appointed beginning in
+1.  Both Contributor and Community Seats will be appointed beginning in
 July 2020. The appointments for the Contribution and Community seat types will
 expire on staggered dates. After the initial term for both seats, all seats
 will have an annual term.
-1.  Contribution Seat terms expire on January 1 and Community Seat terms expire
-on July 1. If necessary, a company holding a Contribution Seat may change the
+1.  Contributor Seat terms expire on January 31 and Community Seat terms expire
+on July 31. If necessary, a company holding a Contributor Seat may change the
 appointed individual at any time during the term.
 1.  No Contributing Company can have more than 5 seats in total on the Steering
 Committee.
@@ -56,11 +57,12 @@ Committee.
     which are controlled by a common third party entity; and affiliate
     companies, will be treated together as a single entity, referred to as a
     Contributing Company.
-1.  There shall be nine **Contribution Seats** allocated based on contribution
-to the project. The measurements for effort and contributions can change over
-time via the approval process of the Steering committee members. The current
-measurement is based on by the number of merged pull requests on GitHub over the
-one year period prior to the Contribution Seat assignments:
+1.  There shall be nine **Contributor Seats**.  Their allocation is determined
+by the approximate effort and expenditure on the Istio project.  Each year, the
+Steering Committee will meet and vote on an exact formula and procedure for
+determining allocation, and publish this to the istio/community repository;
+modifications subsequent to the annual publication of rules shall be considered
+modifications to the Steering Committee Charter.
     1.  The top three contributing companies to Istio are eligible for
     Contribution Seats, proportional to their contribution.
         1.  Each company is allocated one seat;
@@ -81,25 +83,30 @@ one year period prior to the Contribution Seat assignments:
             that is of a non-code nature in the 12 months prior to the election,
             and are granted a vote for the election by a simple majority vote of
             the Steering Committee.
+        1.  No Contributing Company can hold more than one Community Seat.
         1.  Community Seats are maintained for the term by the individual, even
         if they change their company affiliation.
             1.  If an individual changes company affiliation mid-term in a way
             that is incompatible with the company representation policies in
-            this Charter, the individual may keep their seat for the duration of
-            the term.
-    1.  Two Community Seats will be appointed through a vote of the Steering
-    Committee after the community election.
-        1.  These seats are intended to diversify perspectives and expertise on
-        the Committee.
-    1.  Because the goal of Community Seats is to increase the perspectives on
-    the Steering Committee, employees of a Contributing Company are ineligible
-    to be elected to hold a Community Seat.
-1.  At all meetings of the Steering Committee, at least 60% of the Seats shall
-constitute a quorum for voting purposes. The vote of an affirmative vote of 60%
-of the Seats present at the time of the vote shall be the decision of the
-Steering Committee. However, any changes to the Steering Committee Charter shall
-require a super-majority vote of at least two-thirds of the Steering Committee
-seats.
+            this Charter, the individual will be considered to have resigned
+            their seat and the first eligible runner-up from the previous
+            election will replace them for the duration of the term. If there
+            is no first runner-up eligible to serve in the as per these rules,
+            then the Steering Committee shall vote by simple majority to replace
+            the seat for the term.
+            1.  Because the goal of Community Seats is to increase the
+            perspectives on the Steering Committee, employees of a Contributing
+            Company are ineligible to be elected to hold a Community Seat.
+1.  A simple majority of Seats shall be sufficient to convene a meeting of the
+Steering Committee, one nominating, and the rest agreeing, over email. Meeting
+proposals shall be circulated to all Seats, and time, location, and medium shall
+be selected to be as convenient as possible. All Seats shall be given at least
+one week written notice that a meeting of the Steering Committee will be held.
+1. At all meetings of the Steering Committee convened under this charter, at
+least 60% of the Seats shall constitute a quorum for voting purposes. The vote
+of an affirmative vote of 60% of the Seats present at the time of the vote shall
+be the decision of the Steering Committee. However, any changes to the Steering
+Committee Charter shall require a vote of 80% of the Steering Committee Seats.
 
 ## Committee meetings
 

--- a/STEERING-COMMITTEE.md
+++ b/STEERING-COMMITTEE.md
@@ -98,7 +98,8 @@ one year period prior to the Contribution Seat assignments:
 constitute a quorum for voting purposes. The vote of an affirmative vote of 60%
 of the Seats present at the time of the vote shall be the decision of the
 Steering Committee. However, any changes to the Steering Committee Charter shall
-require a vote of 80% of the Steering Committee Seats.
+require a super-majority vote of at least two-thirds of the Steering Committee
+seats.
 
 ## Committee meetings
 

--- a/STEERING-COMMITTEE.md
+++ b/STEERING-COMMITTEE.md
@@ -129,17 +129,14 @@ Seats in Steering are held by a company, not by the individual users. Currently 
 When the Istio project was founded, we decided that having strong corporate
 leadership was needed for the project to ensure continued velocity.
 
+*What Happens If Someone Leaves the Project or Decides to Leave Steering?*
+
 In that case, the company will select another representative to hold the seat.
-This has happened twice to date. Dan Berg filled a seat vacated by Shriram
-Rajagopalan, and Dan Ciruli filled a seat vacated by Varun Talwar.
 
 *What Happens If Someone Leaves the Project or Decides to Leave Steering?*
 
-The same applies; the company will select another representative to hold the seat.
-
-*What Happens If Someone Leaves the Project or Decides to Leave Steering?*
-
-The same applies; the company will select another representative to hold the seat.
+The same applies; the company will select another representative to hold the
+seat.
 
 ## Getting in touch
 

--- a/STEERING-COMMITTEE.md
+++ b/STEERING-COMMITTEE.md
@@ -41,14 +41,14 @@ invested in the success of the Istio project to participate in business and
 non-technical decision-making.
 1.  All members should abide by the project
 [Code of Conduct](CONTRIBUTING.md#code-of-conduct).
-1.  There are two types of seats on the Steering Committee: Contributor Seats
+1.  There are two types of seats on the Steering Committee: Contribution Seats
 and Community Seats.
 1.  Both Contributor and Community Seats will be appointed beginning in
 July 2020. The appointments for the Contribution and Community seat types will
 expire on staggered dates. After the initial term for both seats, all seats
 will have an annual term.
-1.  Contributor Seat terms expire on January 31 and Community Seat terms expire
-on July 31. If necessary, a company holding a Contributor Seat may change the
+1.  Contribution Seat terms expire on January 31 and Community Seat terms expire
+on July 31. If necessary, a company holding a Contribution Seat may change the
 appointed individual at any time during the term.
 1.  No Contributing Company can have more than 5 seats in total on the Steering
 Committee.
@@ -57,7 +57,7 @@ Committee.
     which are controlled by a common third party entity; and affiliate
     companies, will be treated together as a single entity, referred to as a
     Contributing Company.
-1.  There shall be nine **Contributor Seats**.  Their allocation is determined
+1.  There shall be nine **Contribution Seats**.  Their allocation is determined
 by the approximate effort and expenditure on the Istio project.  Each year, the
 Steering Committee will meet and vote on an exact formula and procedure for
 determining allocation, and publish this to the istio/community repository;

--- a/STEERING-COMMITTEE.md
+++ b/STEERING-COMMITTEE.md
@@ -19,7 +19,11 @@ and ratification of bylaws for the Steering Committee and Technical Oversight
 Committee.
 1. Establishing and enforcing principles to guide the Istio project.
 1. Fostering an environment for a healthy and happy community of developers,
+<<<<<<< HEAD
 contributors, vendors, and users.
+=======
+contributors, and users.
+>>>>>>> 94726b0... Update STEERING-COMMITTEE.md
 1. Defining, evolving, and defending a
 [Code of Conduct](CONTRIBUTING.md#code-of-conduct).
 1. Advising the trademark owner on issues relating to the Istio trademark and
@@ -40,6 +44,7 @@ disputes that arise as part of the project.
 invested in the success of the Istio project to participate in business and
 non-technical decision-making.
 1.  All members should abide by the project Code of Conduct.
+<<<<<<< HEAD
 1.  There are two types of seats on the Steering Committee: Contribution Seats
 and Community Seats.
 1.  Both Contribution and Community Seats will be appointed beginning in
@@ -48,6 +53,16 @@ expire on staggered dates. After the initial term for both seats, all seats
 will have an annual term.
 1.  Contribution Seat terms expire on January 1 and Community Seat terms expire
 on July 1. If necessary, a company holding a Contribution Seat may change the
+=======
+1.  There are two types of seats on the Steering Committee: Contributor Seats
+and Community Seats.
+1.  Both Contributor and Community Seats will be appointed beginning in
+July 2020. The appointments for the Contribution and Community seat types will
+expire on staggered dates. After the initial term for both seats, all seats
+will have an annual term.
+1.  Contributor Seat terms expire on January 1 and Community Seat terms expire
+on July 1. If necessary, a company holding a Contributor Seat may change the
+>>>>>>> 94726b0... Update STEERING-COMMITTEE.md
 appointed individual at any time during the term.
 1.  No Contributing Company can have more than 5 seats in total on the Steering
 Committee.
@@ -56,6 +71,7 @@ Committee.
     which are controlled by a common third party entity; and affiliate
     companies, will be treated together as a single entity, referred to as a
     Contributing Company.
+<<<<<<< HEAD
 1.  There shall be nine **Contribution Seats** allocated based on contribution to
 the project. The measurements for effort and contributions can change over time
 via the approval process of the Steering committee members. The current
@@ -63,6 +79,14 @@ measurement is based on by the number of merged pull requests on GitHub over the
 one year period prior to the Contribution Seat assignments:
     1.  The top three contributing companies to Istio are eligible for
     Contribution Seats, proportional to their contribution.
+=======
+1.  There shall be nine **Contributor Seats**. Their allocation is determined
+by the approximate effort and expenditure on the Istio project, as approximated
+by the number of merged pull requests on GitHub over the one year period prior
+to the Contributor Seat assignments:
+    1.  The top three contributing companies to Istio are eligible for
+    Contributor Seats, proportional to their contribution.
+>>>>>>> 94726b0... Update STEERING-COMMITTEE.md
         1.  Each company is allocated one seat;
         1.  The remaining six seats are allocated based on percentage project
         contribution, with no Contributing Company exceeding 5 seats in total
@@ -129,17 +153,26 @@ Seats in Steering are held by a company, not by the individual users. Currently 
 When the Istio project was founded, we decided that having strong corporate
 leadership was needed for the project to ensure continued velocity.
 
+<<<<<<< HEAD
 In that case, the company will select another representative to hold the seat.
 This has happened twice to date. Dan Berg filled a seat vacated by Shriram
 Rajagopalan, and Dan Ciruli filled a seat vacated by Varun Talwar.
+=======
+*What Happens If Someone Leaves the Company They Represent?*
+
+In that case, the company will select another represenative to hold the seat. This has happened twice to date. Dan Berg filled a seat vacated by Shriram Rajagopalan, and Dan Ciruli filled a seat vacated by Varun Talwar.
+>>>>>>> 94726b0... Update STEERING-COMMITTEE.md
 
 *What Happens If Someone Leaves the Project or Decides to Leave Steering?*
 
 The same applies; the company will select another representative to hold the seat.
+<<<<<<< HEAD
 
 *What Happens If Someone Leaves the Project or Decides to Leave Steering?*
 
 The same applies; the company will select another representative to hold the seat.
+=======
+>>>>>>> 94726b0... Update STEERING-COMMITTEE.md
 
 ## Getting in touch
 


### PR DESCRIPTION
The Istio Steering Committee oversees community outreach, ecosystem engagement, and project governance. To date, Steering Committee seats were granted to founders (IBM and Google) and were approximately allocated based on contribution. While this let us get going and move quickly, we’ve outgrown this loose structure, and as the project evolves and adoption grows, so should its leadership opportunities.

This PR proposes a new Steering Committee charter, with two kinds of seats, each with equal voting weight: Contributor Seats and Community Seats. Contributor Seats will be allocated proportionally to company contributions; Community Seats are open to any member who has made a contribution to the project and are voted on by their fellow contributors. With this proposed new structure, community members making an impact on the project -- through both code and non-code contributions -- will have a voice and opportunities to impact how the project grows.

