### PR TITLE
Remove 404 github user

### DIFF
--- a/org/istio.yaml
+++ b/org/istio.yaml
@@ -225,7 +225,6 @@ orgs:
     - tanjunchen
     - tariq1890
     - tbarrella
-    - thangbn
     - theganyo
     - therealmitchconnors
     - tiswanso


### PR DESCRIPTION
Its questionable if this should even fail the CI (it still works, just
fails), but apparently if a user deletes there account CI goes red. This
github account no longer exists

If you are joining the org, please fill out the template below:

- [ ] I have reviewed the [community membership guidelines](https://github.com/istio/community/blob/master/ROLES.md#member)
- [ ] I have reviewed the [contribution guidelines](https://github.com/istio/community/blob/master/CONTRIBUTING.md)
- [ ] I have enabled [2FA on my GitHub account](https://github.com/settings/security)
- [ ] I have joined the [Istio discussion board](https://discuss.istio.io) and subscribed to the [Contributors](https://discuss.istio.io/c/contributors) category
- [ ] I have joined [Istio's Slack workspace](https://istio.slack.com) (fill-out this [form](https://docs.google.com/forms/d/e/1FAIpQLSfdsupDfOWBtNVvVvXED6ULxtR4UIsYGCH_cQcRr0VcG1ZqQQ/viewform) to join)

List your company name, or indicate Individual if you're not affiliated with a company:

Provide a link to at least one PR that you have successfully pushed to one
of the Istio repos:
