### PR TITLE
Move Operations out of Test and Release (reduce GH mail?)

### DIFF
--- a/org/teams.yaml
+++ b/org/teams.yaml
@@ -64,6 +64,15 @@ teams:
       - yangminzhu
       - yxue
     teams:
+      Operations Maintainers:
+        description: Maintainers of Operations.
+        members:
+          - chaodaig
+          - chases2
+          - cjwagner
+          - e-blackwelder
+          - fejta
+          - michelle192837
       WG - Config Maintainers:
         description: Maintainers for the Config working group.
         members:
@@ -225,6 +234,7 @@ teams:
           WG - Test and Release Maintainers/Operations:
             description: Maintainers of Operations.
             members:
+              - chaodaig
               - chases2
               - cjwagner
               - e-blackwelder


### PR DESCRIPTION
I also added chaodaig bringing in #421.

Note that I removed the WG prefix since this isn't a WG.

Once this new group is created, we can update CODEOWNERS in test-infra to use the new group and then remove the old sub team from here.