### PR TITLE
Test & Release Maintainers/Operations replaced by Operations Maintainers

### DIFF
--- a/org/teams.yaml
+++ b/org/teams.yaml
@@ -232,16 +232,6 @@ teams:
           - sdake
           - stevenctl
           - therealmitchconnors
-        teams:
-          WG - Test and Release Maintainers/Operations:
-            description: Maintainers of Operations.
-            members:
-              - chaodaig
-              - chases2
-              - cjwagner
-              - e-blackwelder
-              - fejta
-              - michelle192837
       WG - User Experience Maintainers:
         description: Maintainers for the User Experience working group.
         members:


### PR DESCRIPTION
The most common reason to send a PR to this repository is to join the Istio org.  If you are joining, please fill out this template.  If you are not, please **delete all the below**.

The group was copied in #442, they CODEOWNERS was changed in https://github.com/istio/test-infra/pull/2935, so now we can remove the old group.