### PR TITLE
add our new steering members to the list in github

### DIFF
--- a/org/teams.yaml
+++ b/org/teams.yaml
@@ -395,6 +395,10 @@ teams:
       - rvennam
       - smawson
       - ssuchter
+      - nrjpoddar
+      - christian-posta
+      - hzxuzhonghu
+      - ZackButcher
   Technical Oversight Committee:
     description: Members of the Istio TOC.
     members:

--- a/org/teams.yaml
+++ b/org/teams.yaml
@@ -385,19 +385,19 @@ teams:
   Steering Committee:
     description: members of istio steering committee
     members:
+      - christian-posta
       - craigbox
       - dcberg
+      - hzxuzhonghu
       - knrc
       - linsun
       - louiscryan
+      - nrjpoddar      
       - oaktowner
       - pnambiarsf
       - rvennam
       - smawson
       - ssuchter
-      - nrjpoddar
-      - christian-posta
-      - hzxuzhonghu
       - ZackButcher
   Technical Oversight Committee:
     description: Members of the Istio TOC.


### PR DESCRIPTION
@craigbox @rvennam just realized our new members are not getting the privileges to the steering github group.