### PR TITLE
Replace Jacob Delgado with Neeraj Poddar for Product Security WG lead

### DIFF
--- a/WORKING-GROUPS.md
+++ b/WORKING-GROUPS.md
@@ -74,7 +74,7 @@ Each working group has one or more leads which coordinate the activities of the 
 <img width="30px" src="https://avatars3.githubusercontent.com/u/821270?s=80&v=4">  | [Mitch Connors](https://github.com/therealmitchconnors) | Google  | User Experience
 <img width="30px" src="https://avatars1.githubusercontent.com/u/10537847?s=400&v=4"> | [Eric Van Norman](https://github.com/ericvn)       | IBM        | Test and Release
 &nbsp;                                                                               | [Limin Wang](https://github.com/liminw)            | Google     | Security
-<img width="30px" src="https://avatars3.githubusercontent.com/u/12534779?s=400&v=4"> | [Neeraj Poddar](https://github.com/nrjpoddar)      | Aspen Mesh | Product Security
+<img width="30px" src="https://avatars3.githubusercontent.com/u/38300436?s=400&v=4"> | [Jacob Delgado](https://github.com/jacob-delgado)  | Aspen Mesh | Product Security
 <img width="30px" src="https://avatars0.githubusercontent.com/u/1016047?s=400&v=4">  | [Lizan Zhou](https://github.com/lizan)             | Tetrate    | Networking - Data Plane, Security
 &nbsp;                                                                               | [Rama Chavali](https://github.com/ramaraochavali)  | Salesforce | Networking - Control Plane
 


### PR DESCRIPTION
Neeraj has stepped down as lead and I have replaced him. Approval from TOC was done Friday Oct 2, 2020.
