### PR TITLE
Add permissions in enhancements repo

### DIFF
--- a/org/gen.go
+++ b/org/gen.go
@@ -94,6 +94,7 @@ var repos = map[string]github.RepoPermissionLevel{
 	"cni":             github.Write,
 	"common-files":    github.Write,
 	"cri":             github.Write,
+	"enhancements":    github.Write,
 	"envoy":           github.Write,
 	"gogo-genproto":   github.Write,
 	"installer":       github.Write,


### PR DESCRIPTION
This adds the same permissions for the enhancements repo that we have on other repositories. 

@linsun @howardjohn  PTAL. I ran 

```
go run org/gen.go --output "${OUT_DIR}/istio.yaml"
```
and did a visual comparison. Also ran make test. The resulting istio.yaml looks valid to me.