### PR TITLE
Update sync-org.sh

### DIFF
--- a/prow/sync-org.sh
+++ b/prow/sync-org.sh
@@ -29,5 +29,5 @@ go run org/gen.go --output "${OUT_DIR}/istio.yaml"
 
 echo "Generated configuration: $(cat "${OUT_DIR}/istio.yaml")"
 
-peribolos --fix-org --fix-org-members --fix-teams --fix-team-members \
+peribolos --fix-org --fix-org-members --fix-teams --fix-team-members --fix-team-repos \
 	--config-path "${OUT_DIR}/istio.yaml" --github-token-path /etc/github-token/oauth --confirm


### PR DESCRIPTION
We have added permissions to grant users write permissions to the enhancements repo in Istio, but it is currently not working. 

In the logs for: https://storage.googleapis.com/istio-prow/logs/sync-org_community_postsubmit/174/build-log.txt, we see:

```
Skipping org repositories configuration
```

Looking at https://github.com/kubernetes/test-infra/blob/master/prow/cmd/peribolos/main.go#L96, this message is created when the `fix-team-repos` flag has not been set for the Peribolos command and should allow allow adding/removing permissions to repos. This command adds the flag. 
