### PR TITLE
Add link to YouTube playlist of meeting recordings.

### DIFF
--- a/TECH-OVERSIGHT-COMMITTEE.md
+++ b/TECH-OVERSIGHT-COMMITTEE.md
@@ -56,7 +56,8 @@ Artifact | Link
 Discussion Forum | [Forum](https://discuss.istio.io/c/technical-oversight-committee) 
 Docs | [Folder](https://drive.google.com/corp/drive/u/0/folders/0BzW5bSyKst8JOXRyZVNaVFZuRUk)
 Meeting Notes | [Notes](https://docs.google.com/document/d/13lxJqtlaQhmV2EwsNnS6h-_O4pobZQZuMjrzOeMgVI0/edit#heading=h.ipnfbx7g04vg)
-Meeting Link | [Hangouts Meet](https://meet.google.com/dsa-qqig-kwq?hs=122)
+Meeting Link | [Hangouts Meet](https://meet.google.com/aof-rirb-ijs)
+Meeting Recordings | [YouTube](https://www.youtube.com/playlist?list=PL7wB27eZmdfc4YPa8y3hk8BG3r8INCpRo)
 
 ## Committee meetings
 


### PR DESCRIPTION
We changed the meeting link so we could record, and now we have recordings on YouTube, so added a link to that playlist.