### PR TITLE
Add Jacob Delgado to T&R maintainers

### DIFF
--- a/org/developers.yaml
+++ b/org/developers.yaml
@@ -80,6 +80,7 @@ developers:
 - istio-policy-bot
 - istio-testing
 - jackkleeman
+- jacob-delgado
 - jasonwzm
 - JHDST
 - JimmyCYJ

--- a/org/members.yaml
+++ b/org/members.yaml
@@ -20,7 +20,6 @@ members:
 - helight
 - imjoey
 - istio-release-robot
-- jacob-delgado
 - jasminejaksic
 - Jason-ZW
 - jasonall

--- a/org/teams.yaml
+++ b/org/teams.yaml
@@ -27,6 +27,7 @@ teams:
       - hzxuzhonghu
       - incfly
       - irisdingbj
+      - jacob-delgado
       - jasonwzm
       - JimmyCYJ
       - john-a-joyce
@@ -248,6 +249,7 @@ teams:
           - fejta
           - fpesce
           - howardjohn
+          - jacob-delgado
           - johnma14
           - jwendell
           - linsun
@@ -419,7 +421,7 @@ teams:
       - knrc
       - linsun
       - louiscryan
-      - nrjpoddar     
+      - nrjpoddar
       - pnambiarsf
       - rvennam
       - smawson


### PR DESCRIPTION
This is to add @jacob-delgado to the Test and Release maintainers. 