### PR TITLE
Add release 1.10 managers

### DIFF
--- a/org/teams.yaml
+++ b/org/teams.yaml
@@ -332,6 +332,11 @@ teams:
         - jacob-delgado
         - shamsher31
         - stevenctl
+      Release Managers - 1.10:
+        description: Release managers for Istio 1.10
+        members:
+        - Monkeyanator
+        - ZhiHanZ
   Repo Admins:
     description: Folks with admin permission on all repos.
     members:


### PR DESCRIPTION
Add release managers for Istio 1.10, these two confirmed from last TOC meeting, potentially will add another