### PR TITLE
Remove Francois from admins

### DIFF
--- a/org/teams.yaml
+++ b/org/teams.yaml
@@ -348,7 +348,6 @@ teams:
       - istio-release-robot
       - istio-testing
       - linsun
-      - rshriram
     repos:
       api: admin
       bots: admin

--- a/org/teams.yaml
+++ b/org/teams.yaml
@@ -343,7 +343,6 @@ teams:
     description: Folks with admin permission on all repos.
     members:
       - duderino
-      - fpesce
       - howardjohn
       - istio-policy-bot
       - istio-release-robot


### PR DESCRIPTION
@fpesce  left Istio a few months ago. He said that he would like to remain involved to a limited extent if possible, but I think it's safe to remove him from admins.