### PR TITLE
Temoprarily revert triage

### DIFF
--- a/org/teams.yaml
+++ b/org/teams.yaml
@@ -450,19 +450,19 @@ teams:
       - kmoneal
       - litong01
     repos:
-      api: triage
-      bots: triage
-      client-go: triage
-      cni: triage
-      cri: triage
-      envoy: triage
-      installer: triage
-      istio: triage
-      istio.io: triage
-      operator: triage
-      pkg: triage
-      proxy: triage
-      tools: triage
+      api: write
+      bots: write
+      client-go: write
+      cni: write
+      cri: write
+      envoy: write
+      installer: write
+      istio: write
+      istio.io: write
+      operator: write
+      pkg: write
+      proxy: write
+      tools: write
   Triagers:
     description: Folks that perform issue & pr triage.
     members:


### PR DESCRIPTION
This temporarily reverts the test for the triage role. The permissions had been implemented in Kubernetes GitHub library but not Peribolos itself causing post submit to fail. Our testing is blocked until https://github.com/kubernetes/test-infra/pull/22233 merges

Fyi @kailun-qin @Kmoneal @litong01 -- thanks again for testing. 