### PR TITLE
Restore triage test group

### DIFF
--- a/org/teams.yaml
+++ b/org/teams.yaml
@@ -450,19 +450,19 @@ teams:
       - kmoneal
       - litong01
     repos:
-      api: write
-      bots: write
-      client-go: write
-      cni: write
-      cri: write
-      envoy: write
-      installer: write
-      istio: write
-      istio.io: write
-      operator: write
-      pkg: write
-      proxy: write
-      tools: write
+      api: triage
+      bots: triage
+      client-go: triage
+      cni: triage
+      cri: triage
+      envoy: triage
+      installer: triage
+      istio: triage
+      istio.io: triage
+      operator: triage
+      pkg: triage
+      proxy: triage
+      tools: triage
   Triagers:
     description: Folks that perform issue & pr triage.
     members:


### PR DESCRIPTION
This reverts commit 77182b07473e81e8e82b86983fbadcf4879ec259.

https://github.com/kubernetes/test-infra/pull/22233 was merged to Peribolos so that now has `triager` permission. The build tools have been updated to pick this up. This should allow us to resume our testing.

