### PR TITLE
Update org default perms to triage

### DIFF
--- a/org/gen.go
+++ b/org/gen.go
@@ -127,10 +127,12 @@ func convertConfig(cfg Organization) org.FullConfig {
 		Members: cfg.Developers,
 	}
 
+	triagePerm := github.Triage
 	istio := org.Config{
 		Metadata: org.Metadata{
-			Name:        strptr("Istio"),
-			Description: strptr("Connect, secure, control, and observe services."),
+			Name:                        strptr("Istio"),
+			Description:                 strptr("Connect, secure, control, and observe services."),
+			DefaultRepositoryPermission: &triagePerm,
 		},
 		Teams: cfg.Teams,
 		// Members list shouldn't contain admins


### PR DESCRIPTION
This sets the default permissions for the Istio organization to `triage`