### PR TITLE
Revert "Update org default perms to triage"

### DIFF
--- a/org/gen.go
+++ b/org/gen.go
@@ -127,12 +127,10 @@ func convertConfig(cfg Organization) org.FullConfig {
 		Members: cfg.Developers,
 	}
 
-	triagePerm := github.Triage
 	istio := org.Config{
 		Metadata: org.Metadata{
-			Name:                        strptr("Istio"),
-			Description:                 strptr("Connect, secure, control, and observe services."),
-			DefaultRepositoryPermission: &triagePerm,
+			Name:        strptr("Istio"),
+			Description: strptr("Connect, secure, control, and observe services."),
 		},
 		Teams: cfg.Teams,
 		// Members list shouldn't contain admins


### PR DESCRIPTION
GitHub doesn't yet let us use triage for a default permission. See: https://docs.github.com/en/rest/reference/orgs#update-an-organization--parameters

