### PR TITLE
Add new Steering members as Istio org members

### DIFF
--- a/org/members.yaml
+++ b/org/members.yaml
@@ -35,6 +35,7 @@ members:
 - christian-posta
 - cjwagner
 - clarketm
+- CloudJason
 - clyang82
 - cmluciano
 - costinm
@@ -59,6 +60,7 @@ members:
 - draveness
 - dreadbird
 - duderino
+- duglin
 - dwradcliffe
 - dzdx
 - e-blackwelder
@@ -260,6 +262,7 @@ members:
 - tbarrella
 - theganyo
 - therealmitchconnors
+- thisisnotapril
 - TianTianBigWang
 - tiswanso
 - truongnh1992


### PR DESCRIPTION
Jason, Doug and April aren't Istio org members, so I can't add them to the steering group.