### PR TITLE
Remove truongnh1992 from members

### DIFF
--- a/org/members.yaml
+++ b/org/members.yaml
@@ -265,7 +265,6 @@ members:
 - thisisnotapril
 - TianTianBigWang
 - tiswanso
-- truongnh1992
 - tvieira
 - utako
 - venilnoronha


### PR DESCRIPTION
GitHub says that truongnh1992 was previously a member of the Istio organization, but no longer is and hasn't contributed to Istio since 2020. This is causing issues with Peribolos when the Prow job attempts to configure a user that used to be a member but no longer is. To fix our Peribolos config, this PR removes them. 

I have created https://github.com/kubernetes/test-infra/issues/22723 to track the root cause with Kubernetes/test-infra.

@truongnh1992 Thanks for your prior contributions. If you'd like to remain a member of the Istio organization, apologies. Please add yourself back to the members file. We'd love to have your contributions. 