### PR TITLE
Configure Peribolos to configure repos

### DIFF
--- a/prow/sync-org.sh
+++ b/prow/sync-org.sh
@@ -29,5 +29,5 @@ go run org/gen.go --output "${OUT_DIR}/istio.yaml"
 
 echo "Generated configuration: $(cat "${OUT_DIR}/istio.yaml")"
 
-peribolos --fix-org --fix-org-members --fix-teams --fix-team-members \
+peribolos --fix-org --fix-org-members --fix-teams --fix-team-members --fix-team-repos\
 	--config-path "${OUT_DIR}/istio.yaml" --github-token-path /etc/github-token/oauth --confirm


### PR DESCRIPTION
Currently Peribolos configures teams but not  team permissions within repos. This updates it to configure both. 