### PR TITLE
Create language about special Community Seat elections

### DIFF
--- a/steering/CHARTER.md
+++ b/steering/CHARTER.md
@@ -81,7 +81,11 @@ and community, beginning in August 2020.
         the seat for the term.
     1. Because the goal of Community Seats is to increase the perspectives on
     the Steering Committee, employees of a Company that holds Contribution
-    Seats are ineligible to be elected to hold a Community Seat.
+    Seats are ineligible to hold a Community Seat.
+        1. If a Community Seat thus becomes vacant due to the holding company
+        earning a Contribution Seat, a special election will be held in the
+        weeks following these events, in the same manner as described above
+        for the regular Community Seat elections.
 1. A simple majority of Seats shall be sufficient to call a vote of the
 Steering Committee, one nominating, and the rest agreeing, over email. Voting
 shall be done electronically, in a manner agreed on by the Steering Committee.

--- a/steering/CHARTER.md
+++ b/steering/CHARTER.md
@@ -82,10 +82,10 @@ and community, beginning in August 2020.
     1. Because the goal of Community Seats is to increase the perspectives on
     the Steering Committee, employees of a Company that holds Contribution
     Seats are ineligible to hold a Community Seat.
-        1. If a Community Seat thus becomes vacant due to the holding company
-        earning a Contribution Seat, a special election will be held in the
-        weeks following these events, in the same manner as described above
-        for the regular Community Seat elections.
+        1. If a Community Seat becomes vacant due to a Company earning a
+        Contribution Seat while holding a Community Seat, a special election
+        will be held, in the manner descried above for the annual Community
+        Seat elections.
 1. A simple majority of Seats shall be sufficient to call a vote of the
 Steering Committee, one nominating, and the rest agreeing, over email. Voting
 shall be done electronically, in a manner agreed on by the Steering Committee.


### PR DESCRIPTION
In the 2021/07/02 Steering Committee, we discussed what happens if the company of a holder of a Community Seat earns a Contribution Seat. We raised the idea of holding a special election in ~Feb, immediately following the appointment of the Contribution Seat. This PR is language that describes this.

As this is a change to the Steering charter, it will require an affirmative vote of at least 80% of the Seats, or 11 of the 13.
