### PR TITLE
Update TL list

### DIFF
--- a/org/teams.yaml
+++ b/org/teams.yaml
@@ -570,18 +570,17 @@ teams:
       - douglas-reid
       - ericvn
       - esnible
-      - fpesce
       - frankbu
       - howardjohn
+      - jacob-delgado
       - liminw
       - linsun
       - lizan
       - mandarjog
+      - Monkeyanator
       - myidpt
       - nrjpoddar
       - ostromart
-      - rshriram
-      - sdake
       - stevenctl
       - suryadu
   enhancements-maintainers:

--- a/org/teams.yaml
+++ b/org/teams.yaml
@@ -580,7 +580,6 @@ teams:
       - Monkeyanator
       - myidpt
       - nrjpoddar
-      - ostromart
       - stevenctl
       - suryadu
   enhancements-maintainers:


### PR DESCRIPTION
Updated the list of TLs

Removed:
- Francois Pesce
- Steve Dake
- Martin Ostrowski
- Shriram Rajagopalan

Added:
- Jacob Delgado
- Sam Naster (Monkeyanator)