### PR TITLE
Add release managers page and remove 1.1 and 1.2 release managers

### DIFF
--- a/RELEASE_MANAGERS.md
+++ b/RELEASE_MANAGERS.md
@@ -1,0 +1,73 @@
+# Current Release Managers
+
+## 1.11
+
+* [Jonh Wendell](https://github.com/jwendell)
+* [Ryan King](https://github.com/ryantking)
+* [Steve Zhang](https://github.com/zhlsunshine)
+
+## 1.10
+
+* [Sam Naser](https://github.com/Monkeyanator)
+* [Zhihan Zhang](https://github.com/ZhiHanZ)
+
+## 1.9
+
+* [Jacob Delgado](https://github.com/jacob-delgado)
+* [Shamsher Ansari](https://github.com/shamsher31)
+* [Steven Landow](https://github.com/stevenctl)
+
+# Emeritus Members
+
+We would like to acknowledge previous release managers for their contribution to
+the success of the Istio community:
+
+## 1.8
+
+* [Pengyuan Bian](https://github.com/bianpengyuan)
+* [Greg Hanson](https://github.com/GregHanson)
+
+## 1.7
+
+* [Cynthia Coan](https://github.com/Mythra)
+* [Jimmy Chen](https://github.com/JimmyCYJ)
+* [Jonh Wendell](https://github.com/jwendell)
+
+## 1.6
+
+* [Jacob Delgado](https://github.com/jacob-delgado)
+* [Iris Ding](https://github.com/irisdingbj)
+* [Brian Avery](https://github.com/brian-avery)
+
+## 1.5
+
+* [Daniel Grimm](https://github.com/dgn)
+* [Francois Pesce](https://github.com/fpesce)
+* [Eric Van Norman](https://github.com/ericvn)
+* [Mariam John](https://github.com/johnma14)
+
+## 1.4
+
+* [Jonh Wendell](https://github.com/jwendell)
+* [John Howard](https://github.com/howardjohn)
+* [Eric Van Norman](https://github.com/ericvn)
+
+## 1.3
+
+* [Steve Dake](https://github.com/sdake)
+* [Brian Avery](https://github.com/brian-avery)
+* [Romain Lenglet](https://github.com/rlenglet)
+
+## 1.2
+
+* [Francois Pesce](https://github.com/fpesce)
+
+## 1.1
+
+* [Josh Blatt](https://github.com/duderino)
+
+
+
+
+
+

--- a/org/teams.yaml
+++ b/org/teams.yaml
@@ -421,57 +421,6 @@ teams:
       release-builder: admin
       test-infra: admin
       tools: admin
-    teams:
-      Release Managers - 1.1:
-        description: Release managers for Istio 1.1
-        members:
-          - duderino
-        repos:
-          api: admin
-          bots: admin
-          client-go: admin
-          cni: admin
-          common-files: admin
-          community: admin
-          cri: admin
-          enhancements: admin
-          envoy: admin
-          fortio-deployment: admin
-          gogo-genproto: admin
-          installer: admin
-          istio: admin
-          istio.io: admin
-          operator: admin
-          pkg: admin
-          proxy: admin
-          release-builder: admin
-          test-infra: admin
-          tools: admin
-      Release Managers - 1.2:
-        description: Release managers for Istio 1.2
-        members:
-          - fpesce
-        repos:
-          api: admin
-          bots: admin
-          client-go: admin
-          cni: admin
-          common-files: admin
-          community: admin
-          cri: admin
-          enhancements: admin
-          envoy: admin
-          fortio-deployment: admin
-          gogo-genproto: admin
-          installer: admin
-          istio: admin
-          istio.io: admin
-          operator: admin
-          pkg: admin
-          proxy: admin
-          release-builder: admin
-          test-infra: admin
-          tools: admin
   Steering Committee:
     description: members of istio steering committee
     members:


### PR DESCRIPTION
This creates a release managers page with emeritus members. It also removes the 1.1 and 1.2 release manager teams, while adding them to emeritus. 