### PR TITLE
Add maintainers to api

### DIFF
--- a/org/teams.yaml
+++ b/org/teams.yaml
@@ -66,6 +66,7 @@ teams:
       - yangminzhu
       - yxue
     repos:
+        api: write
         enhancements: write
         istio: write
     teams:


### PR DESCRIPTION
This sets `github.com/istio/api` up such that maintainers in the istio org have the ability to approve pull requests. This means that  pull requests will require approval from one maintainer & one TOC member before merging. 

https://github.com/istio/api/pull/2064