### PR TITLE
Update T&R WG Lead, alphabetize list by last name

### DIFF
--- a/WORKING-GROUPS.md
+++ b/WORKING-GROUPS.md
@@ -59,21 +59,21 @@ Each working group has one or more leads which coordinate the activities of the 
 
 &nbsp;                                                                               | Name                                               | Company    | Groups
 -------------------------------------------------------------------------------------|----------------------------------------------------|------------|-------
-<img width="30px" src="https://avatars3.githubusercontent.com/u/8484260?s=400&v=4">  | [Brian Avery](https://github.com/brian-avery)      | Red Hat    | Test and Release, Product Security
-&nbsp;                                                                               | [Costin Manolache](https://github.com/costinm)     | Google     | Environments
+&nbsp;                                                                               | [Rama Chavali](https://github.com/ramaraochavali)  | Salesforce | Networking - Control Plane
+<img width="30px" src="https://avatars3.githubusercontent.com/u/821270?s=80&v=4">    | [Mitch Connors](https://github.com/therealmitchconnors) | Google  | User Experience
+<img width="30px" src="https://avatars3.githubusercontent.com/u/38300436?s=400&v=4"> | [Jacob Delgado](https://github.com/jacob-delgado)  | Aspen Mesh | Product Security, Environments
 <img width="30px" src="https://avatars1.githubusercontent.com/u/623453?s=400&v=4">   | [John Howard](https://github.com/howardjohn)       | Google     | Networking
 &nbsp;                                                                               | [Mandar Jog](https://github.com/mandarjog)         | Google     | Extensions and Telemetry
+&nbsp;                                                                               | [Steven Landow](https://github.com/stevenctl)      | Google     | Networking - Control Plane
 <img width="30px" src="https://avatars0.githubusercontent.com/u/102881?s=400&v=4">   | [Oliver Liu](https://github.com/myidpt)            | Google     | Security, Product Security
+&nbsp;                                                                               | [Costin Manolache](https://github.com/costinm)     | Google     | Environments
+&nbsp;                                                                               | [Sam Naser](https://github.com/monkeyanator)       | Google     | Environments
 <img width="30px" src="https://avatars2.githubusercontent.com/u/21148125?s=400&v=4"> | [Douglas Reid](https://github.com/douglas-reid)    | Google     | Extensions and Telemetry
 <img width="30px" src="https://avatars3.githubusercontent.com/u/3237651?s=400&v=4">  | [Ed Snible](https://github.com/esnible)            | IBM        | User Experience
-<img width="30px" src="https://avatars3.githubusercontent.com/u/821270?s=80&v=4">    | [Mitch Connors](https://github.com/therealmitchconnors) | Google  | User Experience
 <img width="30px" src="https://avatars1.githubusercontent.com/u/10537847?s=400&v=4"> | [Eric Van Norman](https://github.com/ericvn)       | IBM        | Test and Release
 &nbsp;                                                                               | [Limin Wang](https://github.com/liminw)            | Google     | Security
-<img width="30px" src="https://avatars3.githubusercontent.com/u/38300436?s=400&v=4"> | [Jacob Delgado](https://github.com/jacob-delgado)  | Aspen Mesh | Product Security, Environments
+<img width="30px" src="https://avatars.githubusercontent.com/u/125759?s=400&v=4">    | [Jonh Wendell](https://github.com/jwendell)        | Red Hat    | Test and Release
 <img width="30px" src="https://avatars0.githubusercontent.com/u/1016047?s=400&v=4">  | [Lizan Zhou](https://github.com/lizan)             | Tetrate    | Networking - Data Plane, Security
-&nbsp;                                                                               | [Rama Chavali](https://github.com/ramaraochavali)  | Salesforce | Networking - Control Plane
-&nbsp;                                                                               | [Sam Naser](https://github.com/monkeyanator) | Google     | Environments
-&nbsp;                                                                               | [Steven Landow](https://github.com/stevenctl) | Google     | Networking - Control Plane
 
 ## Getting in touch
 

--- a/org/teams.yaml
+++ b/org/teams.yaml
@@ -514,13 +514,13 @@ teams:
   Working Group Leads:
     description: Working group leads - for easy communication in github
     members:
-      - brian-avery
       - douglas-reid
       - ericvn
       - esnible
       - frankbu
       - howardjohn
       - jacob-delgado
+      - jwendell
       - liminw
       - linsun
       - lizan


### PR DESCRIPTION
Update T&R co-lead replacing Brian with Jonh (approved by TOC 9/20/21). I made the assumption Brian is also no longer a PSWG lead, but didn't know of a possible replacement there.

I also alphabetized the list go Leads by last name similar to the Steering Committee list. Ordering by WG might be another idea.
