### PR TITLE
Test for fixing post submit job failures

### DIFF
--- a/org/members.yaml
+++ b/org/members.yaml
@@ -154,7 +154,6 @@ members:
 - knightXun
 - knrc
 - kramerul
-- kramvan1
 - kushthedude
 - kyessenov
 - l8huang
@@ -215,7 +214,6 @@ members:
 - nrjpoddar
 - nschhina
 - oaktowner
-- objectiser
 - orangegzx
 - ostromart
 - panjf2000


### PR DESCRIPTION
The post submit job has been failing since November 17th: https://prow.istio.io/job-history/gs/istio-prow/logs/sync-org_community_postsubmit

The failure causes the job to end early so new members are not getting added to the Members team list and thus are missing some permissions like editing wikis.

Looking at the failing logs I see several messages like:
```
{"component":"unset","error":"status code 422 not one of [200], body: {\"message\":\"The request could not be processed.\",\"documentation_url\":\"https://docs.github.com/rest/reference/orgs#set-organization-membership-for-a-user\"}","file":"/tmp/test-infra/prow/cmd/peribolos/main.go:498","func":"main.configureOrgMembers.func1","level":"warning","msg":"UpdateOrgMembership(istio, kramvan1, false) failed","severity":"warning","time":"2022-01-05T18:50:21Z"}
...
{"component":"unset","error":"status code 422 not one of [200], body: {\"message\":\"The request could not be processed.\",\"documentation_url\":\"https://docs.github.com/rest/reference/orgs#set-organization-membership-for-a-user\"}","file":"/tmp/test-infra/prow/cmd/peribolos/main.go:498","func":"main.configureOrgMembers.func1","level":"warning","msg":"UpdateOrgMembership(istio, objectiser, false) failed","severity":"warning","time":"2022-01-05T18:50:23Z"}
```

While I am not sure what these users may have changed in their profiles, perhaps removing 2FA, it seems that maybe removing these members to verify that we can actually get the post-submit task to complete sync'ing successfully.

I don't see either person on the maintainer/member lists on eng.istio.io. Maybe if one of them decides they do need membership we can verify why their profiles fail.