### PR TITLE
Update product security repo permissions

### DIFF
--- a/org/teams.yaml
+++ b/org/teams.yaml
@@ -241,8 +241,9 @@ teams:
           - nrjpoddar
           - yangminzhu
         repos:
-          proxy: write
           envoy: write
+          istio: write
+          proxy: write
       WG - Security Maintainers:
         description: Maintainers for the Security working group
         members:

--- a/org/teams.yaml
+++ b/org/teams.yaml
@@ -234,12 +234,11 @@ teams:
           - jacob-delgado
           - justinpettit
           - jwendell
-          - lambdai
           - lei-tang
           - lgadban
           - linsun
           - nrjpoddar
-          - yangminzhu
+          - shankgan
         repos:
           envoy: write
           istio: write

--- a/org/teams.yaml
+++ b/org/teams.yaml
@@ -228,6 +228,7 @@ teams:
       WG - Product Security Maintainers:
         description: Maintainers for the Product Security working group.
         members:
+          - amjain-vmware
           - andream12345
           - GregHanson
           - howardjohn

--- a/org/teams.yaml
+++ b/org/teams.yaml
@@ -230,6 +230,7 @@ teams:
         members:
           - amjain-vmware
           - andream12345
+          - didier-grelin
           - GregHanson
           - howardjohn
           - jacob-delgado

--- a/org/teams.yaml
+++ b/org/teams.yaml
@@ -229,6 +229,7 @@ teams:
         description: Maintainers for the Product Security working group.
         members:
           - andream12345
+          - GregHanson
           - howardjohn
           - jacob-delgado
           - justinpettit
@@ -239,6 +240,9 @@ teams:
           - linsun
           - nrjpoddar
           - yangminzhu
+        repos:
+          proxy: write
+          envoy: write
       WG - Security Maintainers:
         description: Maintainers for the Security working group
         members:


### PR DESCRIPTION
Per TOC discussion on July 11, resolve permission issue with Product Security team so they are able to push patch branches to repos during security release