### PR TITLE
Add Product Security Members

### DIFF
--- a/org/members.yaml
+++ b/org/members.yaml
@@ -11,6 +11,7 @@ members:
 - aliariff
 - AllenZMC
 - ameer00
+- amjain-vmware
 - anandkumarpatel
 - andraxylia
 - andream12345
@@ -71,6 +72,7 @@ members:
 - devlinmr
 - dgn
 - dhawton
+- didier-grelin
 - diemtvu
 - dmitri-d
 - domechn


### PR DESCRIPTION
Adding Amit Jain (VMware) and Didier Grelin (Google).  Both are members of the Product Security and Vulnerability work group.

- [ ] I have reviewed the [community membership guidelines](https://github.com/istio/community/blob/master/ROLES.md#member)
- [ ] I have reviewed the [contribution guidelines](https://github.com/istio/community/blob/master/CONTRIBUTING.md)
- [ ] I have enabled [2FA on my GitHub account](https://github.com/settings/security)
- [ ] I have joined the [Istio discussion board](https://discuss.istio.io) and subscribed to the [Contributors](https://discuss.istio.io/c/contributors) category
- [ ] I have joined [Istio's Slack workspace](https://slack.istio.io)

List your company name, or indicate Individual if you're not affiliated with a company:

Provide a link to at least one PR that you have successfully pushed to one of the Istio repos:
