### PR TITLE
Add Solo.io  Ambient Mesh contributors to steering 2022 VOTERS list

### DIFF
--- a/steering/elections/2022/VOTERS.md
+++ b/steering/elections/2022/VOTERS.md
@@ -16,9 +16,11 @@ If you feel you have standing in the Istio community but are not listed here, pl
 - Arhell
 - aryan16
 - bianpengyuan
+- birkland
 - chaodaiG
 - chases2
 - Chen-Xintong
+- christian-posta
 - chizhg
 - cjwagner
 - cnvergence
@@ -29,10 +31,12 @@ If you feel you have standing in the Istio community but are not listed here, pl
 - dddddai
 - deveshkandpal1224
 - devincd
+- djannot
 - dgn
 - dhawton
 - douglas-reid
 - drivebyer
+- EItanya
 - eliavem
 - ericvn
 - fatedier
@@ -44,6 +48,7 @@ If you feel you have standing in the Istio community but are not listed here, pl
 - howardjohn
 - hueifeng
 - hzxuzhonghu
+- ilevine
 - ingwonsong
 - irisdingbj
 - jacob-delgado
@@ -59,6 +64,7 @@ If you feel you have standing in the Istio community but are not listed here, pl
 - jzhupup
 - kebe7jun
 - kerthcet
+- kdorosh
 - kfaseela
 - kinzhi
 - Kmoneal
@@ -82,6 +88,8 @@ If you feel you have standing in the Istio community but are not listed here, pl
 - NiuYinlong1994
 - nmittler
 - nmnellis
+- npolshakova
+- nrjpoddar
 - orangegzx
 - ostromart
 - PetrMc
@@ -133,6 +141,7 @@ If you feel you have standing in the Istio community but are not listed here, pl
 - YonkaFang
 - youhonglian
 - yskopets
+- yuval-k
 - yxxhero
 - zackzhangkai
 - zaunist

--- a/steering/elections/2022/VOTERS.md
+++ b/steering/elections/2022/VOTERS.md
@@ -9,6 +9,7 @@ The criteria for voter eligibility can be found in the [election guide](README.m
 If you feel you have standing in the Istio community but are not listed here, please fill in the [voting exception form](https://forms.gle/ucNfjUN6ruzJ3mL26). If your application is approved by a simple majority vote of the Steering Committee, you will be added.
 
 - Aakash2017
+- abhijoglekar
 - AdamKorcz
 - AllenZMC
 - ameer00
@@ -41,6 +42,7 @@ If you feel you have standing in the Istio community but are not listed here, pl
 - douglas-reid
 - drivebyer
 - EItanya
+- ejj
 - eliavem
 - ericvn
 - fatedier
@@ -64,6 +66,7 @@ If you feel you have standing in the Istio community but are not listed here, pl
 - johnzheng1975
 - jtischer-acasi
 - jupblb
+- justinpettit
 - jwendell
 - jzhupup
 - kebe7jun
@@ -120,6 +123,7 @@ If you feel you have standing in the Istio community but are not listed here, pl
 - shriramsharma
 - shuaijinchao
 - silenceshell
+- skyfirefrancisz
 - SpecialYang
 - stevenctl
 - stewartbutler


### PR DESCRIPTION
The following members from Solo.io contributed to Ambient Mesh. See the bottom of the announcement blog for the full list of folks: 
https://istio.io/latest/blog/2022/introducing-ambient-mesh/

Aaron Birkland, Kevin Dorosh, Denis Jannot, Yuval Kohavi, Idit Levine, Neeraj Poddar, Nina Polshakova, Christian Posta, Eitan Yarmush

Their work was done in a branch and did not get reflected in the standard contributor data. 

This PR is meant to be in lieu of every person submitting a new voter exception form
