### PR TITLE
Fix common makefile to copy files

### DIFF
--- a/common/Makefile.common.mk
+++ b/common/Makefile.common.mk
@@ -99,9 +99,10 @@ update-common:
 	@cd $(TMP)/common-files ; git rev-parse HEAD >files/common/.commonfiles.sha
 	@rm -fr common
 	@CONTRIB_OVERRIDE=$(shell grep -l "refer to Istio" CONTRIBUTING.md)
-	if [ "$(CONTRIB_OVERRIDE)" != "CONTRIBUTING.md" ]; then\
+	@if [ "$(CONTRIB_OVERRIDE)" != "CONTRIBUTING.md" ]; then\
 		rm $(TMP)/common-files/files/CONTRIBUTING.md;\
 	fi
+	@cp -a $(TMP)/common-files/files/* $(shell pwd)
 	@rm -fr $(TMP)/common-files
 
 check-clean-repo:


### PR DESCRIPTION
The common-files makefile that was created temporarily missed the `cp` command. Adding it here so that when the next update happens, things go smoothly.

Also removing the echo from the `if`.