### PR TITLE
Corrections to candidate profile pages for Elekto.

### DIFF
--- a/steering/elections/2022/candidate-ceposta.md
+++ b/steering/elections/2022/candidate-ceposta.md
@@ -4,8 +4,7 @@ ID: ceposta
 info:
   - employer: Solo.io
   - slack: ceposta
-  - twitter: @christianposta
-  - linkedin: /in/ceposta
+  - twitter: christianposta
 -------------------------------------------------------------
 
 ### Here's a paragraph about my contributions to Istio.

--- a/steering/elections/2022/candidate-craigbox.md
+++ b/steering/elections/2022/candidate-craigbox.md
@@ -4,6 +4,7 @@ ID: craigbox
 info:
   - employer: TBA
   - slack: craigbox
+  - twitter: craigbox
 -------------------------------------------------------------
 
 _I am leaving Google on the 10th of October and thus am running as an independent candidate in this election.  My new employer is not currently involved in the Istio project._

--- a/steering/elections/2022/candidate-hzxuzhonghu.md
+++ b/steering/elections/2022/candidate-hzxuzhonghu.md
@@ -2,8 +2,8 @@
 name: Zhonghu Xu
 ID: hzxuzhonghu
 info:
-- employer: Huawei
-- slack: hzxuzhonghu
+  - employer: Huawei
+  - slack: hzxuzhonghu
 -------------------------------------------------------------
 
 <!-- Please make a copy of this template as "candidate-githubid.md" and save it to

--- a/steering/elections/2022/candidate-irisdingbj.md
+++ b/steering/elections/2022/candidate-irisdingbj.md
@@ -4,7 +4,7 @@ ID: irisdingbj
 info:
   - employer: Intel
   - slack: irisdingbj
-  - twitter: @irisdingbj
+  - twitter: irisdingbj
 -------------------------------------------------------------
 
 # Here's a paragraph about my contributions to Istio.

--- a/steering/elections/2022/candidate-kfaseela.md
+++ b/steering/elections/2022/candidate-kfaseela.md
@@ -3,7 +3,7 @@ name: Faseela K
 ID: kfaseela
 info:
   - employer: Ericsson Software Technology
-  - slack: @Faseela K
+  - slack: Faseela K
 -------------------------------------------------------------
 
 ### Here's a paragraph about my contributions to Istio.

--- a/steering/elections/2022/election.yaml
+++ b/steering/elections/2022/election.yaml
@@ -8,6 +8,7 @@ delete_after: True
 show_candidate_fields:
   - employer
   - slack
+  - twitter
 election_officers:
   - rvennam
   - cetezadi


### PR DESCRIPTION
Display the Twitter field, and fix that rendering the 'twitter' field fails if there are @s in it.