### PR TITLE
Add inner team members to outer list - Prevent rmv/add during sync

### DIFF
--- a/org/config_test.go
+++ b/org/config_test.go
@@ -72,7 +72,7 @@ func testTeamMembers(teams map[string]org.Team, admins sets.String, orgMembers s
 
 		// check if all are org members
 		if missing := teamMembers.Difference(orgMembers); len(missing) > 0 {
-			errs = append(errs, fmt.Errorf("the following members of team %s are not org members: %s", teamName, strings.Join(missing.List(), ", ")))
+			errs = append(errs, fmt.Errorf("the following members of team %s are not parent team members: %s", teamName, strings.Join(missing.List(), ", ")))
 		}
 
 		// check if lists are sorted
@@ -84,7 +84,7 @@ func testTeamMembers(teams map[string]org.Team, admins sets.String, orgMembers s
 		}
 
 		if team.Children != nil {
-			errs = append(errs, testTeamMembers(team.Children, admins, orgMembers)...)
+			errs = append(errs, testTeamMembers(team.Children, admins, teamMembers)...)
 		}
 	}
 	return errs

--- a/org/teams.yaml
+++ b/org/teams.yaml
@@ -12,9 +12,20 @@ teams:
   Maintainers:
     description: Maintainers of the Istio project.
     members:
+      - adiprerepa
+      - amjain-vmware
+      - andream12345
+      - aryan16
       - bianpengyuan
+      - carolynhu
+      - chaodaig
+      - chases2
+      - cjwagner
       - costinm
+      - craigbox
+      - davidhauck
       - dgn
+      - didier-grelin
       - diemtvu
       - douglas-reid
       - duderino
@@ -34,16 +45,26 @@ teams:
       - JimmyCYJ
       - john-a-joyce
       - johnma14
+      - justinpettit
       - jwendell
       - kebe7jun
       - kfaseela
+      - knrc
       - kyessenov
       - lambdai
+      - lei-tang
+      - lgadban
       - liminw
       - linsun
+      - listx
+      - litong01
       - lizan
+      - louiscryan
       - mandarjog
+      - michelle192837
+      - Monkeyanator
       - morvencao
+      - mpherman2
       - myidpt
       - Nino-K
       - nmittler
@@ -53,15 +74,21 @@ teams:
       - rcernich
       - richardwxn
       - rootsongjc
+      - rvennam
       - sbezverk
       - sdake
       - shamsher31
+      - shankgan
+      - ssuchter
+      - stevenctl
       - stewartbutler
       - suryadu
       - therealmitchconnors
+      - windsonsea
       - Xunzhuo
       - yangminzhu
       - zhlsunshine
+      - zirain
     repos:
         api: write
         enhancements: write
@@ -92,7 +119,16 @@ teams:
           - frankbu
           - kebe7jun
           - kfaseela
+          - knrc
+          - louiscryan
+          - litong01
+          - nmittler
           - rootsongjc
+          - rvennam
+          - ssuchter
+          - windsonsea
+          - Xunzhuo
+          - zirain
         repos:
           istio.io: write
           tools: write
@@ -286,17 +322,33 @@ teams:
     description: Current set of release managers.
     members:
       - aryan16
+      - bianpengyuan
+      - brian-avery
       - dgn
       - dhawton
       - eliavem
       - ericvn
+      - fpesce
       - GregHanson
       - howardjohn
+      - irisdingbj
+      - jacob-delgado
+      - JimmyCYJ
+      - johnma14
+      - jwendell
+      - Kmoneal
       - lei-tang
       - litong01
       - Monkeyanator
       - SkyfireFrancisZ
+      - Mythra
+      - rlenglet
+      - ryantking
+      - sdake
+      - shamsher31
       - stevenctl
+      - ZhiHanZ
+      - zhlsunshine
       - ZiyangXiao
     repos:
       api: write

--- a/org/teams.yaml
+++ b/org/teams.yaml
@@ -120,8 +120,8 @@ teams:
           - kebe7jun
           - kfaseela
           - knrc
-          - louiscryan
           - litong01
+          - louiscryan
           - nmittler
           - rootsongjc
           - rvennam
@@ -340,12 +340,12 @@ teams:
       - lei-tang
       - litong01
       - Monkeyanator
-      - SkyfireFrancisZ
       - Mythra
       - rlenglet
       - ryantking
       - sdake
       - shamsher31
+      - SkyfireFrancisZ
       - stevenctl
       - ZhiHanZ
       - zhlsunshine


### PR DESCRIPTION
Looking at the sync.org post-submit logs: ex: https://storage.googleapis.com/istio-prow/logs/sync-org_community_postsubmit/1589667055374700544/build-log.txt

there are some 50+ `RemoveTeamMembership` messages where a user is removed from a team, and then later added as part of a sub-team. 

This change just copies all the sub team memberships to the outer level which should reduce the number of `RemoveTeamMembership` calls. The was done for Maintainers, Release Managers, and Docs (Networking didn't have any missing).

Looking at repo privileges, being added to a subteam adds the higher team privileges so this shouldn't be giving anyone more privileges than they currently have.

I did not do anything in terms of removing/cleanup of members.