### PR TITLE
Nominating myself back as a maintainer

### DIFF
--- a/org/teams.yaml
+++ b/org/teams.yaml
@@ -87,6 +87,7 @@ teams:
       - windsonsea
       - Xunzhuo
       - yangminzhu
+      - ymesika
       - zhlsunshine
       - zirain
     repos:


### PR DESCRIPTION
I'm adding myself back as an Istio maintainer after a period which I wasn't involved.
I was previously a network (https://github.com/istio/istio/pull/11053) and environment (https://github.com/istio/istio/pull/9966) owner and removed myself (https://github.com/istio/istio/pull/12608) when moved to a new position.
I'm currently a Solo.io employee in @linsun's team and will be mainly involved in the community contribution.