### PR TITLE
Update 1.16 RM from Tong Li to Mariam John

### DIFF
--- a/RELEASE_MANAGERS.md
+++ b/RELEASE_MANAGERS.md
@@ -4,7 +4,7 @@
 
 * [Daniel Hawton](https://github.com/dhawton)
 * [Ziyang Xiao](https://github.com/ZiyangXiao)
-* [Tong Li](https://github.com/litong01)
+* [Mariam John](https://github.com/johnma14)
 
 ## 1.15
 

--- a/org/teams.yaml
+++ b/org/teams.yaml
@@ -305,7 +305,6 @@ teams:
       - jwendell
       - Kmoneal
       - lei-tang
-      - litong01
       - Monkeyanator
       - Mythra
       - rlenglet
@@ -413,7 +412,7 @@ teams:
         description: Release managers for Istio 1.16
         members:
         - dhawton
-        - litong01
+        - johnma14
         - ZiyangXiao
 
   Repo Admins:


### PR DESCRIPTION
Per the December 12th, 2022 TOC meeting, Mariam is replacing Tong as Release Manger for 1.16 (as well as for 1.17 and 1.18 per https://docs.google.com/spreadsheets/d/1dk__n7Y3EJvjiYZ3u5eGJ6zuNFvtzdkQWn9I1D_q4DA)