### PR TITLE
Update CODE-OF-CONDUCT.md to point to CNCF (correctly)

### DIFF
--- a/CODE-OF-CONDUCT.md
+++ b/CODE-OF-CONDUCT.md
@@ -1,7 +1,4 @@
 # Istio Community Code of Conduct
 
-
-All members of the Istio community must abide by the [CNCF Code of Conduct](cncf-coc).
+All members of the Istio community must abide by the [CNCF Code of Conduct](https://github.com/cncf/foundation/blob/main/code-of-conduct.md).
 Only by respecting each other can we develop a productive, collaborative community.
-
-[cncf-coc]: https://github.com/cncf/foundation/blob/master/code-of-conduct.md


### PR DESCRIPTION
OK, turns out GHFM doesn't support reference links any more?  Ugly, but working, version.