### PR TITLE
Fix sync issue - Remove inactive sbezverk

### DIFF
--- a/org/members.yaml
+++ b/org/members.yaml
@@ -315,7 +315,6 @@ members:
 - saltbo
 - SataQiu
 - saumoh
-- sbezverk
 - scaat
 - scottilee
 - sdake


### PR DESCRIPTION
The sync job has been failing:
```
{"component":"unset","error":"status code 422 not one of [200], body: {\"message\":\"The request could not be processed.\",\"documentation_url\":\"https://docs.github.com/rest/reference/orgs#set-organization-membership-for-a-user\"}","file":"/tmp/test-infra/prow/cmd/peribolos/main.go:492","func":"main.configureOrgMembers.func1","level":"warning","msg":"UpdateOrgMembership(istio, sbezverk, false) failed","severity":"warning","time":"2023-02-23T02:52:01Z"}
```
In the past this was because the developer changed their GitHub settings for Istio. I did try and reach out Serguei on Slack, but didn't get a response. It also looks like his last contribution was in 2019. For now, it might be best to remove the entry to allow the sync to continue. If Serguei wants to contribute again, we can figure out what settings need to be updated at that time.