### PR TITLE
Fix sync-community - Remove Francois (fpesce) as a member

### DIFF
--- a/org/members.yaml
+++ b/org/members.yaml
@@ -114,7 +114,6 @@ members:
 - Fish-pro
 - fisherxu
 - fleeto
-- fpesce
 - frankbu
 - g3n-github-robot
 - gargnupur


### PR DESCRIPTION
The current sync-community job is failing:
```
{"component":"unset","error":"the GitHub API request returns a 403 error: {\"message\":\"Blocked\",\"documentation_url\":\"https://docs.github.com/rest/reference/orgs#set-organization-membership-for-a-user\"}","file":"/tmp/test-infra/prow/cmd/peribolos/main.go:492","func":"main.configureOrgMembers.func1","level":"warning","msg":"UpdateOrgMembership(istio, fpesce, false) failed","severity":"warning","time":"2023-03-27T11:08:35Z"}
```

Remove Francois, fpesce, from the membership.