### PR TITLE
operations: add John and Stewart

### DIFF
--- a/org/teams.yaml
+++ b/org/teams.yaml
@@ -83,6 +83,8 @@ teams:
           - chases2
           - cjwagner
           - listx
+          - stewartbutler
+          - howardjohn
         repos:
           test-infra: write
       WG - Config Maintainers:

--- a/org/teams.yaml
+++ b/org/teams.yaml
@@ -82,9 +82,9 @@ teams:
         members:
           - chases2
           - cjwagner
+          - howardjohn
           - listx
           - stewartbutler
-          - howardjohn
         repos:
           test-infra: write
       WG - Config Maintainers:


### PR DESCRIPTION
This team is small but a critical bottleneck for CI issues which has been a problem in the past. Adding 2 trusted individuals (if I do say so myself) who are familiar with the prow configuration as approvers.
