### PR TITLE
Add Jacob Delgado as Istio Env maintainer

### DIFF
--- a/org/teams.yaml
+++ b/org/teams.yaml
@@ -156,6 +156,7 @@ teams:
           - hanxiaop
           - howardjohn
           - irisdingbj
+          - jacob-delgado
           - linsun
           - litong01
           - Monkeyanator


### PR DESCRIPTION
I already am a codeowner for the helm manifests, see https://github.com/istio/istio/blob/3b2172b92d02a25052cced34f87833d22f499c08/CODEOWNERS#L64

Most PRs to the helm manifests area also require Env maintainer.

PRs:
1. https://github.com/istio/istio/pull/38651
2. https://github.com/istio/istio/pull/36597
3. https://github.com/istio/istio/pull/36583
4. https://github.com/istio/istio/pull/35694
5. https://github.com/istio/istio/pull/35264
6. https://github.com/istio/istio/pull/35174
7. https://github.com/istio/istio/pull/30257
8. https://github.com/istio/istio/pull/25370
9. https://github.com/istio/istio/pull/25386
10. https://github.com/istio/istio/pull/25260
11. https://github.com/istio/istio/pull/25186
12. https://github.com/istio/istio/pull/30257
13. https://github.com/istio/istio/pull/30257
14. https://github.com/istio/istio/pull/22580
15. https://github.com/istio/istio/pull/29358
16. https://github.com/istio/istio/pull/29697
17. https://github.com/istio/istio/pull/35694
18. https://github.com/istio/istio.io/pull/10047
19. https://github.com/istio/istio.io/pull/9098
20. 