### PR TITLE
Update charter to reflect trademark ownership

### DIFF
--- a/steering/CHARTER.md
+++ b/steering/CHARTER.md
@@ -12,8 +12,8 @@ Committee.
 contributors, vendors, and users.
 1. Defining, evolving, and defending a
 [Code of Conduct](../CONTRIBUTING.md#code-of-conduct).
-1. Advising the Open Usage Commons on issues relating to the Istio trademark and
-logo, as well as related conformance programs.
+1. Advising the Cloud Native Computing Foundation (CNCF) on issues relating 
+to the Istio trademark and logo, as well as related conformance programs.
 1. Setting marketing and advocacy direction for the project; establishing a
 publishing schedule and vetting content, encouraging and assisting community
 members in creating content for conferences, fostering an ecosystem of vendors.


### PR DESCRIPTION
Our charter refers to "advising the Open Usage Commons on issues relating 
to the Istio trademark and logo".

Those are now the responsibility of the CNCF, after our submission, so I have updated the charter to match.

Technically this is a change to the charter, albeit a correction, so I'll seek 80% vote from Steering by 👍 on this PR.