### PR TITLE
add TOC members to voters.yaml

### DIFF
--- a/steering/elections/2023/voters.yaml
+++ b/steering/elections/2023/voters.yaml
@@ -110,6 +110,7 @@ eligible_voters:
 - linsun
 - litong01
 - liwenhao0810
+- louiscryan
 - maxbischoff
 - miaoyq
 - monkeyanator
@@ -122,6 +123,7 @@ eligible_voters:
 - niuyinlong1994
 - nmittler
 - nmnellis
+- nrjpoddar
 - nshankar13
 - obaranov1
 - pawan-bishnoi


### PR DESCRIPTION
This PR adds [TOC members](https://github.com/istio/community/blob/master/TECH-OVERSIGHT-COMMITTEE.md#committee-members) as eligible voters for 2023 election.