### PR TITLE
Add therealmitchconnors to ToC list

### DIFF
--- a/org/teams.yaml
+++ b/org/teams.yaml
@@ -439,6 +439,7 @@ teams:
       - linsun
       - louiscryan
       - nrjpoddar
+      - therealmitchconnors
     repos:
       .default: write
   Triagers:


### PR DESCRIPTION
Fixing the bug that Mitch Connors weren't included in the ToC, whereas in fact he has been a member for a while.

