### PR TITLE
Fix sync-community - Remove geeknoid

### DIFF
--- a/org/members.yaml
+++ b/org/members.yaml
@@ -125,7 +125,6 @@ members:
 - g3n-github-robot
 - gargnupur
 - gbaufake
-- geeknoid
 - giantcroc
 - google-admin
 - googlebot


### PR DESCRIPTION
The current sync-community job is failing:
```
{"client":"github","component":"unset","file":"/tmp/test-infra/prow/github/client.go:923","func":"k8s.io/test-infra/prow/github.(*client).log","level":"info","msg":"UpdateOrgMembership(istio, geeknoid, false)","severity":"info","time":"2023-07-26T20:14:20Z"}
{"component":"unset","error":"status code 422 not one of [200], body: {\"message\":\"The request could not be processed.\",\"documentation_url\":\"https://docs.github.com/rest/orgs/members#set-organization-membership-for-a-user\"}","file":"/tmp/test-infra/prow/cmd/peribolos/main.go:477","func":"main.configureOrgMembers.func1","level":"warning","msg":"UpdateOrgMembership(istio, geeknoid, false) failed","severity":"warning","time":"2023-07-26T20:14:20Z"}

```

From the docs:
```
422 | Validation failed, or the endpoint has been spammed.
```

Remove @geeknoid, Martin, from the membership. I'm not sure what Martin did, but maybe he blocked the istio bot.

Martin, you are welcome back anytime, and are still listed as an emeritus maintainer.