### PR TITLE
Adjust timezone link for more consistent results

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ by teams from Google and IBM, in partnership with the Envoy team at Lyft.
 ## Community meeting
 
 We have public, [recorded](https://www.youtube.com/channel/UC-zVlo1F3mUbExQ96fABWcQ), community meetings.
-They happen on the fourth Thursday of every month at 10am US/Pacific. [Map that to your local time](https://www.google.com/search?q=1000+am+in+pst&hl=en).
+They happen on the fourth Thursday of every month at 10am US/Pacific. [Map that to your local time](https://www.google.com/search?q=1000+am+pst&hl=en).
 
 [Join this group](https://groups.google.com/forum/#!forum/istio-community-video-meetings)
 to have the meetings automatically added to your calendar.

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ by teams from Google and IBM, in partnership with the Envoy team at Lyft.
 ## Community meeting
 
 We have public, [recorded](https://www.youtube.com/channel/UC-zVlo1F3mUbExQ96fABWcQ), community meetings.
-They happen on the fourth Thursday of every month at 10am US/Pacific. [Map that to your local time](https://www.google.com/search?q=1000+am+pst&hl=en).
+They happen on the fourth Thursday of every month at 10am US/Pacific. [Map that to your local time](https://time.is/compare/1000_in_San_Francisco,_California).
 
 [Join this group](https://groups.google.com/forum/#!forum/istio-community-video-meetings)
 to have the meetings automatically added to your calendar.


### PR DESCRIPTION
in the [Community Meeting](https://github.com/istio/community#community-meeting) section of the README, a link is given to map the meeting's time to your local timezone.  This link is a google search with the query of "1000 am in pst".  The search result includes a timezone conversion, but it is the opposite of what we expect.  Google infers  we want 10:00am local time in PST, which is inaccurate.  Removing the "in" results in the search result we expect.
