### PR TITLE
Remove obaranov1 as no longer a GH user

### DIFF
--- a/org/members.yaml
+++ b/org/members.yaml
@@ -305,7 +305,6 @@ members:
 - nschhina
 - nshankar13
 - oaktowner
-- obaranov1
 - orangegzx
 - ostromart
 - panjf2000


### PR DESCRIPTION
Remove Oksana Baranova from members as their GitHub is was deleted/changed. The deletion/change causes the post-submit job to fail. If they can provide a new id, we can add it back in. For information, the user was added in https://github.com/istio/community/pull/849. I did attempt to reach out in Slack.