### PR TITLE
Remove missing member, mrshengzyzy

### DIFF
--- a/org/members.yaml
+++ b/org/members.yaml
@@ -289,7 +289,6 @@ members:
 - mpherman2
 - mpvl
 - Mr-Linus
-- mrshengzyzy
 - munnerz
 - munrodg
 - MXuDong


### PR DESCRIPTION
The post-submit sync job is failing as the member, mrshengzyzy, no longer seems to exist in GitHub. This PR removes them. I don't know of a way to figure out if they simply changed the GitHub name. If someone knows a new GitHIb name for mrshengzyzy, we can simply make the change, or if they can reapply for membership.