### PR TITLE
Remove missing member, rrobb-aspen

### DIFF
--- a/org/members.yaml
+++ b/org/members.yaml
@@ -349,7 +349,6 @@ members:
 - rokkiter
 - rootsongjc
 - rosenhouse
-- rrobb-aspen
 - rshriram
 - ruigulala
 - rveerama1


### PR DESCRIPTION
Sync failure:
```
{"component":"unset","file":"/tmp/test-infra/prow/cmd/peribolos/main.go:194","func":"main.main","level":"fatal","msg":"Configuration failed: failed to configure istio teams: failed to update Members members: UpdateTeamMembership(members(Members), rrobb-aspen, false) failed: status code 404 not one of [200], body: {\"message\":\"Not Found\",\"documentation_url\":\"https://docs.github.com/rest/teams/members#add-or-update-team-membership-for-a-user\"}","severity":"fatal","time":"2023-11-10T22:49:04Z"}
```
Another member with a changed/removed GitHub name. We can re-add them if they let us know a new user name.