### PR TITLE
Remove Google-Admin

### DIFF
--- a/org/admins.yaml
+++ b/org/admins.yaml
@@ -1,7 +1,6 @@
 # Please add your name in alphabetical order.
 admins:
 - ericvn
-- google-admin
 - googlebot
 - howardjohn
 - istio-testing

--- a/org/config_test.go
+++ b/org/config_test.go
@@ -116,7 +116,7 @@ func TestIstioOrg(t *testing.T) {
 	admins := normalize(sets.NewString(cfg.Admins...))
 	allOrgMembers := members.Union(admins).Union(members)
 
-	requiredRobots := sets.NewString("istio-testing", "google-admin", "googlebot")
+	requiredRobots := sets.NewString("istio-testing", "googlebot")
 	if !admins.IsSuperset(requiredRobots) {
 		t.Errorf("Missing required robots as admins: %v", requiredRobots.List())
 	}


### PR DESCRIPTION
Google-Admin was used for Google CLA enforcement, which we no longer need