### PR TITLE
org: remove config maintainer group

### DIFF
--- a/org/teams.yaml
+++ b/org/teams.yaml
@@ -90,10 +90,6 @@ teams:
           - howardjohn
           - listx
           - stewartbutler
-      WG - Config Maintainers:
-        description: Maintainers for the Config working group.
-        members:
-          - nmittler
       WG - Docs Maintainers:
         description: Maintainers of the Docs working group.
         members:


### PR DESCRIPTION
This has been obsolete for years; they have no permissions and were disolved as a working group long ago.

(Note: the sole maintainer here, Nate, also maintains other WGs so remains an overall Istio maintainer)
