### PR TITLE
Revert "add member: osswangxining to community members"

### DIFF
--- a/org/members.yaml
+++ b/org/members.yaml
@@ -320,7 +320,6 @@ members:
 - nshankar13
 - oaktowner
 - orangegzx
-- osswangxining
 - ostromart
 - panjf2000
 - Pawan-Bishnoi


### PR DESCRIPTION
Reverts istio/community#1329

The PR linked in the description has a different author. 
I noticed it only after merging, May be @osswangxining can push a new PR with the right description if we revert this. I did ask the question on the original PR, but there was no response.