### PR TITLE
Remove requirement that TOC candidates be a Working Group Lead.

### DIFF
--- a/TECH-OVERSIGHT-COMMITTEE.md
+++ b/TECH-OVERSIGHT-COMMITTEE.md
@@ -63,7 +63,7 @@ Membership in the TOC is determined by a majority vote of the [Steering Committe
 
 While Steering seats are allocated to companies, TOC seats are allocated to individuals, and remain with a person if that person moves to a new employer.
 
-In the event of a vacancy on the TOC, the Steering Committee will solicit candidates for election from the eligible candidates. Eligible candidates are those who have been members of the Istio project for a year, and a maintainer for at least six months.
+In the event of a vacancy on the TOC, the Steering Committee will solicit candidates for election from the eligible candidates. Eligible candidates are those who have been members of the Istio project for at least a year, and a maintainer for at least six months.
 
 ## Committee members
 

--- a/TECH-OVERSIGHT-COMMITTEE.md
+++ b/TECH-OVERSIGHT-COMMITTEE.md
@@ -63,7 +63,7 @@ Membership in the TOC is determined by a majority vote of the [Steering Committe
 
 While Steering seats are allocated to companies, TOC seats are allocated to individuals, and remain with a person if that person moves to a new employer.
 
-In the event of a vacancy on the TOC, the Steering Committee will solicit candidates for election from the eligible candidates. Eligible candidates are those who have been a [Working Group lead](ROLES.md/#lead) for at least 3 months.
+In the event of a vacancy on the TOC, the Steering Committee will solicit candidates for election.  A strong candidate is one who has made broad, sustained technical contributions over an extended period of time.
 
 ## Committee members
 

--- a/TECH-OVERSIGHT-COMMITTEE.md
+++ b/TECH-OVERSIGHT-COMMITTEE.md
@@ -63,7 +63,7 @@ Membership in the TOC is determined by a majority vote of the [Steering Committe
 
 While Steering seats are allocated to companies, TOC seats are allocated to individuals, and remain with a person if that person moves to a new employer.
 
-In the event of a vacancy on the TOC, the Steering Committee will solicit candidates for election.  A strong candidate is one who has made broad, sustained technical contributions over an extended period of time.
+In the event of a vacancy on the TOC, the Steering Committee will solicit candidates for election from the eligible candidates. Eligible candidates are those who have been members of the Istio project for a year, and a maintainer for at least six months.
 
 ## Committee members
 


### PR DESCRIPTION
As the status of Istio Working Groups is a bit up in the air, this removes the requirement that an eligible TOC candidate must be a Working Group Lead.  No new requirements are put in place, but some guidance is given that new members should have made broad, sustained technical contributions over time.
