### PR TITLE
Replace VMware with Broadcom in EARLY-DISCLOSURE.md

### DIFF
--- a/EARLY-DISCLOSURE.md
+++ b/EARLY-DISCLOSURE.md
@@ -42,14 +42,14 @@ will be removed from the early disclosure list.
 
 | Email		| Organization	|
 | ------------- |:-------------:|
+| tanzu.psirt@broadcom.com | Broadcom |
 | istio-security-reports@f5.com | F5 Networks |
 | istio-security-vulnerability-notifications@google.com | Google |
 | argoprod@us.ibm.com | IBM |
+| kube-security@microsoft.com | Microsoft |
 | istio-security@redhat.com | RedHat |
 | cve@solo.io | Solo.io |
 | istio-security@tetrate.io | Tetrate |
-| security@vmware.com | VMware |
-| kube-security@microsoft.com | Microsoft |
 
 ### Membership criteria
 


### PR DESCRIPTION
Broadcom acquired VMware, so this updates the information for their membership in the Product Security Working Group.
