### PR TITLE
org: nominate bleggett as Ztunnel maintainer

### DIFF
--- a/org/teams.yaml
+++ b/org/teams.yaml
@@ -183,6 +183,7 @@ teams:
           WG - Networking Maintainers/Ztunnel:
             description: Maintainers of Ztunnel.
             members:
+              - bleggett
               - howardjohn
               - hzxuzhonghu
               - stevenctl


### PR DESCRIPTION
Ben is an active contributor to Ztunnel an existing maintainer of
networking. Currently we have a large bottleneck in ztunnel review
bandwidth due to a small team.

I would also like to add some more, probably Ian and Jeremy, but since
they are not yet Networking maintainers I think that needs broader
approval.
