### PR TITLE
Remove listx from org to prevent sync failure

### DIFF
--- a/org/members.yaml
+++ b/org/members.yaml
@@ -264,7 +264,6 @@ members:
 - lichuqiang
 - liminw
 - linsun
-- listx
 - litong01
 - liu-xg
 - liwenhao0810

--- a/org/teams.yaml
+++ b/org/teams.yaml
@@ -44,7 +44,6 @@ teams:
       - lei-tang
       - lgadban
       - linsun
-      - listx
       - lizan
       - louiscryan
       - Monkeyanator
@@ -76,7 +75,6 @@ teams:
           - chases2
           - cjwagner
           - howardjohn
-          - listx
           - stewartbutler
       WG - Docs Maintainers:
         description: Maintainers of the Docs working group.


### PR DESCRIPTION
<!-- Is this PR to join the Istio org?  If so, please fill in the below.  If not, delete everything before continuing. -->

Remove @listx from org to prevent sync failure in post-submit job. 

Thanks @listx for your contributions!

Looking at devstats, they have not contributed in the last 6 months. We can check on the failure, likely a GitHub configuration, and re-add them if they so choose.

