### PR TITLE
Fix broken anchor link

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This is the starting point for becoming a contributor - improving code, improvin
 - [Introduction](#introduction)
 - [Istio authors](#istio-authors)
 - [Community meeting](#community-meeting)
-- [How can I help?](#how-can-i-help-)
+- [How can I help?](#how-can-i-help)
 - [Questions and issues](#questions-and-issues)
 
 Other Documents


### PR DESCRIPTION
This change removes a trailing hyphen to fix a broken anchor link in the readme. This is the only anchor link to a header with a question mark, and maybe that's why it could have worked in the past but not now.

I checked it out in Arc and Safari to confirm the replicate the behavior.