### PR TITLE
Refresh operations maintainers

### DIFF
--- a/org/teams.yaml
+++ b/org/teams.yaml
@@ -16,8 +16,6 @@ teams:
       - andream12345
       - aryan16
       - bleggett
-      - chases2
-      - cjwagner
       - costinm
       - craigbox
       - davidhauck
@@ -73,8 +71,7 @@ teams:
       Operations Maintainers:
         description: Maintainers of Operations.
         members:
-          - chases2
-          - cjwagner
+          - dhawton
           - howardjohn
           - stewartbutler
       WG - Docs Maintainers:


### PR DESCRIPTION
These maintainer our prow cluster. Previously, Google's k8s team did
this for us. They stepped down from that role, so we need to fill it.

I put the people here that volunteered and have prow experience. We need
more, but for now we just need more than 1.
