### PR TITLE
Update community links

### DIFF
--- a/ADMINS-FOR-ISTIO.md
+++ b/ADMINS-FOR-ISTIO.md
@@ -6,7 +6,6 @@ access.
 
 | Service | Purpose | Responsible Adults
 |---------|---------|-------------------
-| [Discourse](https://discuss.istio.io) | Discussion forums | [linsun](https://github.com/linsun), [craigbox](https://github.com/craigbox), [thisisnotapril](https://github.com/thisisnotapril), [macruzbar](https://github.com/macruzbar); Mary Radomile from Google OSPO
 | [Docker Hub](https://hub.docker.com) | Container registry | [ericvn](https://github.com/ericvn), [costinm](https://github.com/costinm), [howardjohn](https://github.com/howardjohn), [frankbu](https://github.com/frankbu)
 | [GitHub](https://github.com/istio) | Source control, bug tracking | [howardjohn](https://github.com/howardjohn), [linsun](https://github.com/linsun), [louiscryan](https://github.com/louiscryan)
 | [Google Analytics](https://analytics.google.com/analytics/web/) | Analytics for *istio.io | [davidhauck](https://github.com/davidhauck)
@@ -19,7 +18,7 @@ access.
 | [Google Search Console](https://search.google.com/search-console/about) | Search engine analytics for *istio.io | [davidhauck](https://github.com/davidhauck)
 | [Netlify](https://netlify.com) | Site hosting for *istio.io | [davidhauck](https://github.com/davidhauck)
 | [Prow](https://prow.istio.io) | Primary CI system | [fejta](https://github.com/fetja),  [cjwagner](https://github.com/cjwagner)
-| [Shared Google Drive](https://drive.google.com/corp/drive/folders/0ADmbrU7ueGOUUk9PVA) | Design document storage | [craigbox](https://github.com/craigbox), [linsun](https://github.com/linsun), [louiscryan](https://github.com/louiscryan), [howardjohn](https://github.com/howardjohn), [nrjpoddar](https://github.com/nrjpoddar)
+| [Shared Google Drive](https://drive.google.com/drive/folders/1l_zqgBq_yfc1PfbJiWsFubXBtAz22sau) | Design document storage | [craigbox](https://github.com/craigbox), [justinpettit]https://github.com/justinpettit)
 | [Slack](https://istio.slack.com) | Chat platform | [craigbox](https://github.com/craigbox), [linsun](https://github.com/linsun), [louiscryan](https://github.com/louiscryan)
 | [Twitter](https://twitter.com/IstioMesh) | Istio Twitter account | [craigbox](https://github.com/craigbox), [linsun](https://github.com/linsun), [rvennam](https://github.com/rvennam)
-| [YouTube](https://www.youtube.com/c/istio) | Working group videos | [macruzbar](https://github.com/macruzbar), [craigbox](https://github.com/craigbox), [SkyfireFrancisZ](https://github.com/skyfirefrancisz)
+| [YouTube](https://www.youtube.com/c/istio) | Working group videos | [craigbox](https://github.com/craigbox), [SkyfireFrancisZ](https://github.com/skyfirefrancisz)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,13 +50,13 @@ part of the project.
 ## Design documents
 
 Any substantial design deserves a design document. Design documents are written with Google Docs and
-should be shared with the community by adding the doc to our [shared Drive](https://drive.google.com/corp/drive/folders/0ADmbrU7ueGOUUk9PVA)
+should be shared with the community by adding the doc to our [team drive](https://drive.google.com/drive/folders/1l_zqgBq_yfc1PfbJiWsFubXBtAz22sau)
 and sending a note to the appropriate working group to let people know the doc is there. To get write access
 to the drive, you'll need to be a [member](ROLES.md#member) of the Istio organization.
 
-Anybody can access the shared Drive for reading. To get access to comment, join the
+Anybody can access the team drive for reading. To get access to comment, join the
 [istio-team-drive-access@](https://groups.google.com/forum/#!forum/istio-team-drive-access) group.
-Once you've done that, head to the [shared Drive](https://drive.google.com/corp/drive/folders/0ADmbrU7ueGOUUk9PVA) and
+Once you've done that, head to the [team drive](https://drive.google.com/drive/folders/1l_zqgBq_yfc1PfbJiWsFubXBtAz22sau) and
 behold all the docs.
 
 When documenting a new design, we recommend a 2-step approach:

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ Unsuitable content
 See our [community page](https://istio.io/about/community/) for ways to get involved
 in our community.
 
-To dig deeper, check out the [architecture](https://istio.io/docs/concepts/what-is-istio/#architecture)
+To dig deeper, check out the [architecture](https://istio.io/latest/docs/ops/deployment/architecture/)
 and read some [design docs](./CONTRIBUTING.md#design-documents).
 
 If you're looking for something to do to get your feet wet working on Istio, look for GitHub issues
@@ -92,9 +92,9 @@ and insightful docs. Or maybe a cool blog post?
 
 ## Questions and issues
 
-If you've got questions or issues with using Istio, check our [help page](https://istio.io/help/)
+If you've got questions or issues with using Istio, check our [discussion board](https://github.com/istio/istio/discussions)
 and be sure to connect to our [community](https://istio.io/about/community/) where there's always
 someone ready to lend a hand.
 
 If you're a developer trying to hack on or use the Istio code, head to
-[contributors](https://discuss.istio.io/c/contributors) for help.
+#contributors on the [Istio Slack](https://slack.istio.io/) for help.

--- a/ROLES.md
+++ b/ROLES.md
@@ -36,7 +36,7 @@ privileges.
       <td>
           <p>Outside collaborator of the GitHub Istio organization</p>
           <p>Can submit PRs</p>
-          <p>Read and commenting permission on the Istio Team drive</p>
+          <p>Read and commenting permission on the Istio team drive</p>
       </td>
     </tr>
     <tr>
@@ -47,7 +47,7 @@ privileges.
       </td>
       <td>
           <p>Member of the GitHub Istio organization</p>
-          <p>Edit permission on the Istio Team drive</p>
+          <p>Edit permission on the Istio team drive</p>
           <p>Triage permission on the Istio repos, allowing issues to be manipulated.</p>
       </td>
     </tr>
@@ -141,7 +141,7 @@ the area before being accepted into the source base.
 
 * Has pushed at least one PR to the Istio repositories within the last 6 months.
 
-* Subscribed to [contributors](https://discuss.istio.io/c/contributors)
+* Member of #contributors on the [Istio Slack](https://slack.istio.io)
 
 * Actively contributing to 1 or more areas.
 

--- a/TECH-OVERSIGHT-COMMITTEE.md
+++ b/TECH-OVERSIGHT-COMMITTEE.md
@@ -41,8 +41,7 @@ The TOC’s work includes:
 
 Artifact | Link
 ---|---
-Discussion Forum | [Forum](https://discuss.istio.io/c/technical-oversight-committee)
-Docs | [Folder](https://drive.google.com/corp/drive/folders/1-BLXbKg8mfnXbip4IThz4R4GH2PEsLZO)
+Docs | [Folder](https://drive.google.com/drive/folders/1-BLXbKg8mfnXbip4IThz4R4GH2PEsLZO)
 Meeting Notes | [Notes](https://docs.google.com/document/d/13lxJqtlaQhmV2EwsNnS6h-_O4pobZQZuMjrzOeMgVI0/edit#heading=h.ipnfbx7g04vg)
 Meeting Link | [Google Meet](https://meet.google.com/aof-rirb-ijs)
 Meeting Recordings | [YouTube](https://www.youtube.com/playlist?list=PL7wB27eZmdfc4YPa8y3hk8BG3r8INCpRo)
@@ -92,4 +91,4 @@ the success of the Istio community:
 
 ## Getting in touch
 
-If you'd like to reach out to the committee, please drop a note to [toc@discuss.istio.io](mailto:toc@discuss.istio.io).
+If you'd like to reach out to the committee, please join #toc-steering-questions on the [Istio Slack](https://slack.istio.io/).

--- a/WORKING-GROUP-PROCESSES.md
+++ b/WORKING-GROUP-PROCESSES.md
@@ -47,7 +47,7 @@ See [below](#running-a-working-group) for information on the responsibilities of
 
 * **Prepare a Roadmap**. Create a preliminary 3 month roadmap for what the working group would focus on.
 
-* **Send an Email**. Write up an email with your charter, nominated leads, and roadmap, and post it to [technical-oversight-committee](https://discuss.istio.io/c/technical-oversight-committee).
+* **Send an Email**. Write up an email with your charter, nominated leads, and roadmap, and post it to #toc-steering-questions on the [Istio Slack](https://slack.istio.io/).
 The technical oversight committee will evaluate the request and decide whether the working group should be
 formed, whether it should be merely a subgroup of an existing working group, or whether it should be subsumed by an existing working group.
 
@@ -57,17 +57,15 @@ Once approval has been granted by the technical oversight committee to form a wo
 steps to establish the working group:
 
 * **Create a Google Drive Folder**. Create a folder to hold your working group documents within this parent
-[folder](https://drive.google.com/corp/drive/u/0/folders/0B7huSKYaiUN5LVdBeElXUGt3UGs). Call your folder "GROUP_NAME".
+[folder](https://drive.google.com/drive/folders/15y-2OIcjP9DNF7WLvHL0Hyn_XXxaYoOm). Call your folder "GROUP_NAME".
 
 * **Create a Roadmap Document**. Create a document in the above folder and call it "GROUP_NAME Group Roadmap". Put your initial
 roadmap in the document.
 
-* **Create a Discourse Category**. Create a new category on <https://discuss.istio.io> and give it the name of your working group.
-
 * **Register the Working Group**. Go to [WORKING-GROUPS.md](https://github.com/istio/community/blob/master/WORKING-GROUPS.md) and
 add your working group name, the names of the leads, the working group charter, and a link to the meeting you created.
 
-* **Announce your Working Group**. Post a note [contributors](https://discuss.istio.io/c/contributors)
+* **Announce your Working Group**. Post a note to #contributors on the Istio Slack (https://slack.istio.io/)
 to announce your new working group. Include your charter in the post.
 
 * **Attend the Combined Working Group Meeting**. Check the meeting agenda to verify if something was added relative to your working group.
@@ -77,8 +75,7 @@ Congratulations, you now have a fully formed working group!
 
 ### Dissolving a working group
 
-Some working groups are ephemeral or naturally reach the end of their useful life. Working group leads can petition to dissolve their working
-groups by posting to [technical-oversight-committee](https://discuss.istio.io/c/technical-oversight-committee). The
+Some working groups are ephemeral or naturally reach the end of their useful life. Working group leads can petition to dissolve their working groups in a TOC meeting. The
 technical oversight committee also reserves the right to dissolve or recharter working groups over time as necessary.
 
 ## Leads

--- a/WORKING-GROUPS.md
+++ b/WORKING-GROUPS.md
@@ -10,31 +10,28 @@ Most community activity is organized into *working groups*.
 Working groups follow the [contributing](CONTRIBUTING.md) guidelines although each of these groups may operate a little differently depending on
 their needs and workflow.
 
-When the need arises, a new working group can be created, please post to [technical-oversight-committee](https://discuss.istio.io/c/technical-oversight-committee)
-working group if you think a new group is necessary.
+When the need arises, a new working group can be created. Please ask in #toc-steering-questions in the [Istio Slack](https://slack.istio.io/) if you think a new group is necessary.
 
 The working groups generate design docs which are kept in a shared Google Drive.
 Anybody can access the drive for reading and commenting. To get access simply join the
 [istio-team-drive-access@](https://groups.google.com/forum/#!forum/istio-team-drive-access) group.
-Once you've done that, head to the [Community Drive](https://drive.google.com/drive/folders/0ADmbrU7ueGOUUk9PVA) and
+Once you've done that, head to the [team drive](https://drive.google.com/drive/folders/1l_zqgBq_yfc1PfbJiWsFubXBtAz22sau) and
 behold all the docs.
+
+The below links to Slack require you to first be logged into Istio's Slack workspace. Please use [this link](https://slack.istio.io/) if you need to join.
 
 The current working groups are:
 
-| Group | Design Docs | Discussion Forum | Slack Channel | Description
-|-------|-------------|-------|-------|------------
-| Docs | [Folder](https://drive.google.com/drive/folders/16Alb6m30ypLbz3iVv2OTjpqUHO8NJIUv) | [Forum](https://discuss.istio.io/c/contributors/docs) | [#docs](https://istio.slack.com/messages/C50V5EATT/) | User docs, information architecture, istio.io infrastructure
-| Environments | [Folder](https://drive.google.com/drive/folders/16P5sCnSzEk204LHBKYTkC9jEmgzBJy6x) | [Forum](https://discuss.istio.io/c/environment) | [#environments](https://istio.slack.com/messages/C6KA8TTSS/) |  Raw VM support, Hybrid Mesh, Mac/Windows support, Cloud Foundry integration
-| Networking | [Folder](https://drive.google.com/drive/folders/16RDUAJj_LnJM83weyk0WSCeqgtTw8Ogz) | [Forum](https://discuss.istio.io/c/networking) | [#networking](https://istio.slack.com/messages/C38CF1PEC/) | Traffic Management, TCP Support, Additional L7 protocols, Proxy injection
-| Extensions and Telemetry | [Folder](https://drive.google.com/drive/folders/16Jl2ASNQ226h5XmXSAtxx78cs1iSEAYQ) | [Forum](https://discuss.istio.io/c/policies-and-telemetry) | [#extensions-telemetry](https://istio.slack.com/messages/C382V8Q92/) | WebAssembly based extensibility, Istio extensions for features such as Rate Limiting, Tracing, Monitoring, Logging
-| Product Security | [Folder](https://drive.google.com/drive/folders/16gnkbCgO18zkMIk_IHrE_QV2EFqFWe4R) | [Report a vulnerability](https://istio.io/about/security-vulnerabilities/) | | Product Security: Vulnerability, security guidelines, threats
-| Security | [Folder](https://drive.google.com/drive/folders/16eF1aoVnknX1vY853gEIPfoO2-i-FDcU) | [Forum](https://discuss.istio.io/c/security) | [#security](https://istio.slack.com/messages/C3TEGNZ7W/) | Service-to-service Auth, Identity/CA/SecretStore plugins, Identity Federation, End User Auth, Authority Delegation, Auditing
-| Test and Release |[Folder](https://drive.google.com/drive/folders/16M0Ba8uT6-1F71NARhddXDdnk-EE4jEn) | [Forum](https://discuss.istio.io/c/test-and-release) |[#test-and-release](https://istio.slack.com/messages/C6FCV6WN4/) | Build, test, release
-| User Experience | [UX](https://drive.google.com/drive/folders/16CplcqFZTT-5WXDkpi443-ly2RnnA3C5) [_Config (old)_](https://drive.google.com/drive/folders/16W9uDkzrKJM-E5R7_5TGz-PMsAkkoT1s) | [Forum](https://discuss.istio.io/c/UX) | [#user-experience](https://istio.slack.com/messages/CFTRP8NTW/) [#config](https://istio.slack.com/messages/C7KSV4AHJ/)| User experience across Istio, API and CLI guidelines and support
-
-_NOTE: Config working group responsibilities have been merged into User Experience._
-
-To join Istio's Slack workspace, please use [this link](https://slack.istio.io/).
+| Group | Design Docs | Slack Channel | Description
+|-------|-------------|---------------|------------
+| Docs | [Folder](https://drive.google.com/drive/folders/16Alb6m30ypLbz3iVv2OTjpqUHO8NJIUv) | [#docs](https://istio.slack.com/messages/C50V5EATT/) | User docs, information architecture, istio.io infrastructure
+| Environments | [Folder](https://drive.google.com/drive/folders/16P5sCnSzEk204LHBKYTkC9jEmgzBJy6x) | [#environments](https://istio.slack.com/messages/C6KA8TTSS/) |  Raw VM support, Hybrid Mesh, Mac/Windows support, Cloud Foundry integration
+| Networking | [Folder](https://drive.google.com/drive/folders/16RDUAJj_LnJM83weyk0WSCeqgtTw8Ogz) | [#networking](https://istio.slack.com/messages/C38CF1PEC/) | Traffic Management, TCP Support, Additional L7 protocols, Proxy injection
+| Extensions and Telemetry | [Folder](https://drive.google.com/drive/folders/16Jl2ASNQ226h5XmXSAtxx78cs1iSEAYQ) | [#extensions-telemetry](https://istio.slack.com/messages/C382V8Q92/) | WebAssembly based extensibility, Istio extensions for features such as Rate Limiting, Tracing, Monitoring, Logging
+| Product Security | [Folder](https://drive.google.com/drive/folders/16gnkbCgO18zkMIk_IHrE_QV2EFqFWe4R) | [Report a vulnerability](https://istio.io/about/security-vulnerabilities/) | Product Security: Vulnerability, security guidelines, threats
+| Security | [Folder](https://drive.google.com/drive/folders/16eF1aoVnknX1vY853gEIPfoO2-i-FDcU) | [#security](https://istio.slack.com/messages/C3TEGNZ7W/) | Service-to-service Auth, Identity/CA/SecretStore plugins, Identity Federation, End User Auth, Authority Delegation, Auditing
+| Test and Release |[Folder](https://drive.google.com/drive/folders/16M0Ba8uT6-1F71NARhddXDdnk-EE4jEn) | [#test-and-release](https://istio.slack.com/messages/C6FCV6WN4/) | Build, test, release
+| User Experience | [UX](https://drive.google.com/drive/folders/16CplcqFZTT-5WXDkpi443-ly2RnnA3C5) | [#user-experience](https://istio.slack.com/messages/CFTRP8NTW/) | User experience across Istio, API and CLI guidelines and support
 
 ## Working group meetings
 
@@ -79,7 +76,3 @@ Each working group has one or more leads which coordinate the activities of the 
 &nbsp;                                                                               | [Lei Tang](https://github.com/lei-tang)            | Google     | Security, Extensions and Telemetry
 <img width="30px" src="https://avatars1.githubusercontent.com/u/10537847?s=400&v=4"> | [Eric Van Norman](https://github.com/ericvn)       | IBM        | Test and Release
 <img width="30px" src="https://avatars0.githubusercontent.com/u/1016047?s=400&v=4">  | [Lizan Zhou](https://github.com/lizan)             | Aviatrix   | Networking - Data Plane, Security
-
-## Getting in touch
-
-If you'd like to reach out to the working group leads, please drop a note to [wg-leads@discuss.istio.io](mailto:wg-leads@discuss.istio.io).

--- a/steering/elections/2022/candidate-craigbox.md
+++ b/steering/elections/2022/candidate-craigbox.md
@@ -23,7 +23,7 @@ I have worked on Cloud Native since joining Google, supporting Kubernetes since 
 - been a [top 10 contributor](https://istio.teststats.cncf.io/d/9/developer-activity-counts-by-repository-group-table?orgId=1&var-period_name=Last%20year&var-metric=contributions&var-repogroup_name=All&var-country_name=All) (last 12 months) with ~1,000 PR reviews total
 - served as Program Committee chair for IstioCon 2021 and mentor for PC chair for IstioCon 2022
 - increased support for our Chinse community by setting up dedicated IstioCon sessions in China's time zone, supporting Chinese documentation efforts and keynoting the [Istio Community Meetup in China](https://istio.io/latest/blog/2021/istio-community-meetup-china/)
-- administered the Istio Slack and led moderation for [discuss.istio.io](https://discuss.istio.io/)
+- administered the Istio Slack and led moderation for discuss.istio.io
 - represented the Istio project as Program Committee chair for multiple ServiceMeshCon events, including [the upcoming event](https://servicemeshconna22.sched.com/)
 - hosted the [Kubernetes Podcast](https://kubernetespodcast.com/), where I have featured many Istio team members: including [Justin and Ethan](https://kubernetespodcast.com/episode/189-ambient-mesh/), [Mitch](https://kubernetespodcast.com/episode/177-istiocon/), [Lin](https://kubernetespodcast.com/episode/086-invention-ibm-istio/), [Louis](https://kubernetespodcast.com/episode/058-istio-1.2/) and [Dan and Jasmine](https://kubernetespodcast.com/episode/015-istio/)
 


### PR DESCRIPTION
- change Drive links to reflect the new Google Drive layout
- remove mentions of discuss.istio.io and redirect to Slack where appropriate
