### PR TITLE
Add keithmattix as a Policies and Telemetry maintainer

### DIFF
--- a/org/teams.yaml
+++ b/org/teams.yaml
@@ -189,6 +189,7 @@ teams:
       WG - Policies and Telemetry  Maintainers:
         description: Maintainers for the Policy and Telemetry working group.
         members:
+          - keithmattix
           - kyessenov
           - lei-tang
           - zirain


### PR DESCRIPTION
Istio has very few maintainers here and though I'm still learning, I've contributed a handful of upstream envoy PRs as well as 2 recent changes to istio-proxy's telemetry. If existing maintainers have other areas they'd like to see more contributions in, I welcome the feedback!

PRs:
- https://github.com/envoyproxy/envoy/pull/35074
- https://github.com/envoyproxy/envoy/pull/33857
- https://github.com/envoyproxy/envoy/pull/33362
- https://github.com/envoyproxy/envoy/pull/32961
- https://github.com/istio/proxy/pull/5617
- https://github.com/istio/proxy/pull/5514