### PR TITLE
add dhawton to Chinese doc maintainer team

### DIFF
--- a/org/teams.yaml
+++ b/org/teams.yaml
@@ -109,6 +109,7 @@ teams:
             description: Maintainers of the Chinese documentation.
             members:
               - craigbox
+              - dhawton
               - ericvn
               - frankbu
               - kebe7jun


### PR DESCRIPTION
add dhawton to Chinese doc maintainer (as he is a docs infrastructure admin) so he can approve refactoring of examples.
