### PR TITLE
TOC meeting link is outdated

### DIFF
--- a/TECH-OVERSIGHT-COMMITTEE.md
+++ b/TECH-OVERSIGHT-COMMITTEE.md
@@ -43,7 +43,7 @@ Artifact | Link
 ---|---
 Docs | [Folder](https://drive.google.com/drive/folders/1-BLXbKg8mfnXbip4IThz4R4GH2PEsLZO)
 Meeting Notes | [Notes](https://docs.google.com/document/d/13lxJqtlaQhmV2EwsNnS6h-_O4pobZQZuMjrzOeMgVI0/edit#heading=h.ipnfbx7g04vg)
-Meeting Link | [Google Meet](https://meet.google.com/aof-rirb-ijs)
+Meeting Link | [Google Meet](https://meet.google.com/ccb-cxqf-sym)
 Meeting Recordings | [YouTube](https://www.youtube.com/playlist?list=PL7wB27eZmdfc4YPa8y3hk8BG3r8INCpRo)
 
 ## Committee meetings


### PR DESCRIPTION
I assume this changed recently - the ones in the notes is correct, this one in the markdown is not.
