### PR TITLE
Add new TOC charter & election process

### DIFF
--- a/TECH-OVERSIGHT-COMMITTEE.md
+++ b/TECH-OVERSIGHT-COMMITTEE.md
@@ -87,7 +87,7 @@ The TOC's responsibilities include:
 ### Vacancies
 
 1. In the event that a TOC member vacates their seat during their term, a by-election shall be conducted to fill the position for the remainder of the term in accordance with the regular qualification and election procedures.
-2. The Steering Committee may initiate a vote of no confidence in a TOC member. The member shall be removed if the motion is approved by at least 60% of the Steering Committee seats. The vacated seat shall be filled through the regular vacancy process.
+2. The Steering Committee may initiate a vote of no confidence in a TOC member. The member shall be removed if the motion is approved by at least 60% of the Steering Committee seats. The position shall be filled for the remainder of the term through the regular vacancy process.
 
 ## Meetings & process
 

--- a/TECH-OVERSIGHT-COMMITTEE.md
+++ b/TECH-OVERSIGHT-COMMITTEE.md
@@ -3,41 +3,99 @@
 The Istio Technical Oversight Committee (TOC) is responsible for cross-cutting product and design decisions.
 
 * [Charter](#charter)
-* [Committee mechanics](#committee-mechanics)
-* [Committee meetings](#committee-meetings)
-* [Selection and eligibility](#selection-and-eligibility)
-* [Committee members](#committee-members)
+* [Meetings & process](#meetings--process)
+* [Members](#members)
 * [Getting in touch](#getting-in-touch)
 
 ## Charter
 
-* Technical Project Oversight, Direction & Delivery
+The TOC's responsibilities include:
 
-  * Set the overall technical direction and roadmap of the project.
+**Technical Project Oversight, Direction & Delivery**
+
+  * Setting the overall technical direction and roadmap of the project.
   * Resolve technical issues, technical disagreements and escalations within the project.
-  * Set the priorities of individual releases to ensure coherency and proper sequencing.
-  * Approve declaring a new long-term supported (LTS) Istio release.
-  * Approve the creation and dissolution of working groups and approve leadership changes of working groups.
-  * Create proposals based on TOC discussions and bring them to the relevant working groups for discussion.
-  * Approve the creation/deletion of GitHub repositories, along with other high-level administrative issues around GitHub and our other tools.
+  * Setting the priorities of individual releases to ensure coherency and proper sequencing.
+  * Declaring [maturity levels for Istio features](https://istio.io/latest/docs/releases/feature-stages/).
+  * Approving the creation and dissolution of working groups and approve leadership changes of working groups.
+  * Creating proposals based on TOC discussions and bring them to the relevant working groups for discussion.
+  * Approving the creation/deletion of GitHub repositories, along with other high-level administrative issues around GitHub and our other tools.
 
-* Happy Healthy Community
+**Maintaining a Happy, Healthy Community**
 
-  * Establish and maintain the overall technical governance guidelines for the project.
-  * Decide which sub-projects are part of the Istio project, including accepting new sub-projects and pruning existing sub-projects to
+  * Establishing and maintaining the overall technical governance guidelines for the project.
+  * Deciding which sub-projects are part of the Istio project, including accepting new sub-projects and pruning existing sub-projects to
     maintain community focus.
-  * Ensure the team adheres to our [code of conduct](CONTRIBUTING.md#code-of-conduct) and respects our [values](VALUES.md).
-  * Foster an environment for a healthy and happy community of developers and contributors.
+  * Ensuring the team adheres to our [code of conduct](CONTRIBUTING.md#code-of-conduct) and respects our [values](VALUES.md).
+  * Fostering an environment for a healthy and happy community of developers and contributors.
 
-## Committee mechanics
+### Committee Mechanics
 
-The TOC’s work includes:
+1. The work of the TOC shall encompass:
+    * Conducting regular committee meetings to address pertinent topics and producing published meeting notes.
+    * Creating, reviewing, approving, and publishing technical project governance documents.
+    * Formulating proposals for consideration by individual working groups to guide their efforts toward achieving a unified project-wide objective.
+    * Reviewing, addressing, and commenting on project issues.
+    * Serving as a high-level advisory body for technical inquiries or designs submitted by working groups.
+2. The TOC is expected to operate by consensus. Consequently, there shall be an even maximum number of seats at all times.
+3. TOC members shall act independently, in their individual capacities, and shall prioritize the best interests of the project and the community. TOC membership is associated with the individual, irrespective of their employment status.
+4. A standing joint session of the TOC and Steering Committee shall be convened at least once per calendar quarter. During these sessions, both the TOC and Steering Committee shall present on topics pertinent to their respective charters and responsibilities.
+5. A special joint session of the TOC and Steering Committee must be held no later than 1 month following the ratification of the Steering Committee for its annual term. In this session, the Steering Committee shall consult with the TOC to evaluate contribution dynamics, workload, and effectiveness of both the Steering Committee and TOC. This review aims to determine whether any changes are necessary to further advance the project.
 
-* Regular committee meetings to discuss hot topics, resulting in a set of published meeting notes.
-* Create, review, approve and publish technical project governance documents.
-* Create proposals for consideration by individual working groups to help steer their work towards a common project-wide objective.
-* Review/address/comment on project issues.
-* Act as a high-level sounding board for technical questions or designs bubbled up by the working groups.
+### Membership and Elections
+
+1. The TOC shall consist of six seats. Should there be an insufficient number of qualified candidates, the TOC may temporarily function with fewer than six members.
+2. Each seat shall be held for a term of 2 years. The election cycles shall be staggered such that half of the seats shall be up for re-election each year. The election process shall commence 2 months subsequent to the ratification of the Steering Committee for that year.
+
+### Qualification and Eligibility
+
+1. Prior to each election, individuals who have served as Istio maintainers for a minimum of 3 months shall be given the opportunity to stand as candidates.
+2. Candidates shall be recognized within the Istio community as collaborative technical leaders with a demonstrated history of leading project design work or engaging in other consensus-building activities.
+3. The Steering Committee and TOC shall jointly ensure a viable pipeline of candidates, including identifying opportunities for mentoring emerging leaders in the project to the point where they are likely to meet the qualification criteria in a future election.
+4. Candidates removed from the TOC by a vote of no confidence within the past 12 months shall be deemed ineligible to stand for election.
+5. The Steering Committee, with assistance from the current TOC, shall evaluate candidates against the following criteria, assessed over the preceding 12 months. A candidate must satisfy the criteria for "Chop Wood, Carry Water" and at least one additional criterion.
+
+  <ul style="list-style-type:none;">
+      <dl>
+          <dt><b><i>Chop Wood, Carry Water:</i></b></dt>
+          <dd>Demonstrates visibility in technical and collaborative aspects of the project, including but not limited to
+              weekly working group meetings, monthly TOC meetings, and Slack discussions.</dd>
+          <dt><b><i>Senior Maintainer:</i></b></dt>
+          <dd>Has authored and merged at least 20 substantial pull requests (PRs).</dd>
+          <dt><b><i>User Champion:</i></b></dt>
+          <dd>
+              Has resolved at least 5 user-reported issues with pull requests (PRs). Demonstrates active engagement in Slack channels or GitHub issues/discussions in support of users.
+          </dd>
+          <dt><b><i>Project Manager:</i></b></dt>
+          <dd>
+              Demonstrates active involvement in organizing the project’s daily operations, including bug triage, roadmap
+              qualification and definition, leading meetings, driving consensus, and organizing community events.
+          </dd>
+          <dt><b><i>Architect:</i></b></dt>
+          <dd>
+              Has produced at least 3 design documents for features incorporated into the project roadmap. Has reviewed at least 10 design documents authored by other community members.
+          </dd>
+      </dl>
+  </ul>
+
+6. Candidates must submit a written application, including a self-assessment against the qualification criteria. The application shall be forwarded to the TOC for confidential feedback and subsequently returned to the Steering Committee.
+7. The Steering Committee shall individually vote on each candidate to determine their suitability for serving on the TOC. An affirmative vote of at least 60% of the seats is required for a candidate to be approved.
+    a. If the number of candidates is fewer than or equal to the number of open seats, this vote shall serve as the election.
+    b. If the number of candidates exceeds the number of open seats, this vote shall qualify candidates to proceed to a second round of voting.
+8. Should there be more qualified candidates than open TOC seats, the Steering Committee shall select the winning candidates via a Condorcet election.
+
+### Vacancies
+
+1. In the event that a TOC member vacates their seat during their term, a by-election shall be conducted to fill the position for the remainder of the term in accordance with the regular qualification and election procedures.
+2. The Steering Committee may initiate a vote of no confidence in a TOC member. The member shall be removed if the motion is approved by at least 60% of the Steering Committee seats. The vacated seat shall be filled through the regular vacancy process.
+
+## Meetings & process
+
+The TOC meets regularly. The meetings are open to anyone interested, so please join us. The meeting schedule is tracked
+on the [working group calendar](WORKING-GROUPS.md#working-group-meetings); please follow the link for more details.
+
+Community members are encouraged to suggest topics for discussion ahead of the TOC meetings, and are invited
+to observe these meetings and engage with the TOC. To suggest a topic, add it to the [agenda](https://docs.google.com/document/d/13lxJqtlaQhmV2EwsNnS6h-_O4pobZQZuMjrzOeMgVI0/edit#heading=h.ipnfbx7g04vg).
 
 Artifact | Link
 ---|---
@@ -46,41 +104,23 @@ Meeting Notes | [Notes](https://docs.google.com/document/d/13lxJqtlaQhmV2EwsNnS6
 Meeting Link | [Google Meet](https://meet.google.com/ccb-cxqf-sym)
 Meeting Recordings | [YouTube](https://www.youtube.com/playlist?list=PL7wB27eZmdfc4YPa8y3hk8BG3r8INCpRo)
 
-## Committee meetings
+## Members
 
-The TOC meets regularly. The meetings are open to anyone interested, so please join us. The meeting schedule is tracked
-on the [working group calendar](WORKING-GROUPS.md#working-group-meetings); please follow the link for more details.
+The current members of the Istio TOC are:
 
-Community members are encouraged to suggest topics for discussion ahead of the TOC meetings, and are invited
-to observe these meetings and engage with the TOC. To suggest a topic, add it to the [agenda](https://docs.google.com/document/d/13lxJqtlaQhmV2EwsNnS6h-_O4pobZQZuMjrzOeMgVI0/edit#heading=h.ipnfbx7g04vg).
+&nbsp; | Name | Company | Term ends
+---|---|---|--
+<img width="30px" src="https://avatars.githubusercontent.com/u/821270?v=4"> | [Mitch Connors](https://github.com/therealmitchconnors)  | Microsoft | 2026
+<img width="30px" src="https://avatars.githubusercontent.com/u/623453?v=4">            | [John Howard](https://github.com/howardjohn)  | Solo.io | 2026
+<img width="30px" src="https://avatars3.githubusercontent.com/u/12534779?s=400&v=4">|    [Neeraj Poddar](https://github.com/nrjpoddar) | Solo.io | 2025
+<img width="30px" src="https://pbs.twimg.com/profile_images/838075233445695489/o2eAYJAV_400x400.jpg"> | [Louis Ryan](https://github.com/louiscryan) | Solo.io | 2025
+<img width="30px" src="https://avatars1.githubusercontent.com/u/1588319?s=400&v=4"> |    [Lin Sun](https://github.com/linsun)          | Solo.io | 2025
+| | *vacant* | | 2026
 
-## Selection and eligibility
-
-Because the group is expected to form, and operate by consensus, there are an even number of seats.
-
-Membership in the TOC is determined by a majority vote of the [Steering Committee](./steering/README.md).
-
-While Steering seats are allocated to companies, TOC seats are allocated to individuals, and remain with a person if that person moves to a new employer.
-
-In the event of a vacancy on the TOC, the Steering Committee will solicit candidates for election from the eligible candidates. Eligible candidates are those who have been members of the Istio project for at least a year, and a maintainer for at least six months.
-
-## Committee members
-
-The members of the TOC are shown below. 
-
-&nbsp; | Name | Company
----|---|---
-<img width="30px" src="https://avatars.githubusercontent.com/u/821270?v=4"> | [Mitch Connors](https://github.com/therealmitchconnors)  | Microsoft
-<img width="30px" src="https://avatars.githubusercontent.com/u/623453?v=4">            | [John Howard](https://github.com/howardjohn)  | Solo.io
-<img width="30px" src="https://avatars3.githubusercontent.com/u/12534779?s=400&v=4">|    [Neeraj Poddar](https://github.com/nrjpoddar) | Solo.io
-<img width="30px" src="https://pbs.twimg.com/profile_images/838075233445695489/o2eAYJAV_400x400.jpg"> | [Louis Ryan](https://github.com/louiscryan) | Solo.io
-<img width="30px" src="https://avatars1.githubusercontent.com/u/1588319?s=400&v=4"> |    [Lin Sun](https://github.com/linsun)          | Solo.io
-<img width="30px" src="https://avatars.githubusercontent.com/u/10537847?v=4">       |    [Eric Van Norman](https://github.com/ericvn)  | IBM
-
-## Emeritus members
+### Emeritus members
 
 We would like to acknowledge previous TOC members for their huge contribution to
-the success of the Istio community:
+the success of the Istio project:
 
 * Martin Taillefer
 * Shriram Rajagopalan
@@ -88,6 +128,7 @@ the success of the Istio community:
 * Joshua Blatt
 * Brian Avery
 * Sven Mawson
+* Eric Van Norman
 
 ## Getting in touch
 


### PR DESCRIPTION
The Istio Steering Commitee is introducing a new charter for the Technical Oversight Committee:

* the number of members remains at 6
* members will now serve 2 year terms
* there is a clearly documented expectation for candidates to qualify for the election, and process by which they can stand
* the Steering Committee will vote every year to (re-) seat 3 members on the TOC. 

This PR serves as a vote for the Steering Committee to ratify the change. Upon ratification, we will immediately begin a by-election to fill the currently vacant seat.

The regular process will begin in 2025 with the three longest serving seats becoming eligible for election.  