### PR TITLE
teams.yaml: Remove Eric and Neeraj from TOC

### DIFF
--- a/org/teams.yaml
+++ b/org/teams.yaml
@@ -310,11 +310,9 @@ teams:
   Technical Oversight Committee:
     description: Members of the Istio TOC.
     members:
-      - ericvn
       - howardjohn
       - linsun
       - louiscryan
-      - nrjpoddar
       - therealmitchconnors
     repos:
       .default: write


### PR DESCRIPTION
Remove Eric and Neeraj, as they've retired from TOC.