### PR TITLE
Add bleggett to docs/infra group

### DIFF
--- a/org/teams.yaml
+++ b/org/teams.yaml
@@ -98,6 +98,7 @@ teams:
           WG - Docs  Maintainers/English:
             description: Maintainers of the English documentation.
             members:
+              - bleggett
               - craigbox
               - dhawton
               - ericvn

--- a/org/teams.yaml
+++ b/org/teams.yaml
@@ -77,6 +77,7 @@ teams:
       WG - Docs Maintainers:
         description: Maintainers of the Docs working group.
         members:
+          - bleggett
           - craigbox
           - davidhauck
           - dhawton

--- a/org/teams.yaml
+++ b/org/teams.yaml
@@ -125,6 +125,7 @@ teams:
           WG - Docs Maintainers/Infra:
             description: Maintainers of the doc build & site infrastructure
             members:
+              - bleggett
               - craigbox
               - davidhauck
               - dhawton


### PR DESCRIPTION
I'm semi-familiar with the docs infra stuff at this point, and I feel like we need more hands there specifically, so this makes sense to me.

I'd also be OK with adding myself to the eng/docs team as well, if that's easier in practice versus only being a member of docs/infra, but that may be less necessary as eng/docs seems reasonably sized already, so I'll defer to current maintainers on that point.

EDIT: actually, I think the way it's set up, I have to add myself to all of them - someone please correct me if that's not the case.