### PR TITLE
Remove deleted github user xocodergit

### DIFF
--- a/org/members.yaml
+++ b/org/members.yaml
@@ -487,7 +487,6 @@ members:
 - xichengliudui
 - Xieql
 - xieydd
-- xocodergit
 - xulingqing
 - Xunzhuo
 - yanggangtony

--- a/org/members.yaml
+++ b/org/members.yaml
@@ -370,6 +370,7 @@ members:
 - rootsongjc
 - rosenhouse
 - rshriram
+- rudrakhp
 - ruigulala
 - rveerama1
 - rvennam


### PR DESCRIPTION
Error in [job](https://prow.istio.io/view/gs/istio-prow/logs/sync-org_community_postsubmit/1851106659791802368):
```
{"component":"unset","level":"fatal","msg":"Configuration failed: failed to configure istio teams: failed to update Members members: UpdateTeamMembership(members(Members), xocodergit, false) failed: status code 404 not one of [200], body: {\"message\":\"Not Found\",\"documentation_url\":\"https://docs.github.com/rest/teams/members#add-or-update-team-membership-for-a-user\",\"status\":\"404\"}","severity":"fatal","time":"2024-10-29T05:19:58Z"}
failed to generate org: exit status 1
```
Probably because user https://github.com/xocodergit might be deleted.