### PR TITLE
maintainers: nominate Keith as a pilot maintainer

### DIFF
--- a/org/teams.yaml
+++ b/org/teams.yaml
@@ -182,6 +182,7 @@ teams:
               - costinm
               - howardjohn
               - hzxuzhonghu
+              - keithmattix
               - ramaraochavali
               - stevenctl
           WG - Networking Maintainers/Ztunnel:


### PR DESCRIPTION
Keith has been reviewing and maintaining code in this area for quite some time now, and I think has shown more than enough expertise to warrant becoming a maintainer here (especially as some others have decreased their activity in Istio recently).

For some background context for those unfamiliar, the 'pilot' group is a sub-group within Networking WG (where Keith is already a maintainer). It was created because Networking is super broad, and Pilot is very specialized + mission critical knowledge.

I've put the other pilot maintainers as reviewers