### PR TITLE
org: Transition inactive maintainers to Emeritus (2024)

### DIFF
--- a/org/emeritus.yaml
+++ b/org/emeritus.yaml
@@ -1,11 +1,13 @@
 # Istio thanks our emeritus maintainers!
 emeritus:
 - adammil2000
+- adiprerepa
 - andraxylia
 - bianpengyuan
 - carolynhu
 - chaodaig
 - clyang82
+- davidhauck
 - diemtvu
 - douglas-reid
 - duderino
@@ -30,6 +32,7 @@ emeritus:
 - lambdai
 - liamawhite
 - litong01
+- lizan
 - loverto
 - mandarjog
 - michelle192837
@@ -42,14 +45,17 @@ emeritus:
 - PiotrSikora
 - pnambiarsf
 - rcaballeromx
+- richardwxn
 - rshriram
 - SataQiu
 - sbezverk
 - sdake
 - SecurityInsanity
 - shamsher31
+- shankgan
 - smawson
 - ssuchter
+- stewartbutler
 - suryadu
 - tiswanso
 - venilnoronha

--- a/org/teams.yaml
+++ b/org/teams.yaml
@@ -11,14 +11,12 @@ teams:
   Maintainers:
     description: Maintainers of the Istio project.
     members:
-      - adiprerepa
       - amjain-vmware
       - andream12345
       - aryan16
       - bleggett
       - costinm
       - craigbox
-      - davidhauck
       - dgn
       - dhawton
       - didier-grelin
@@ -43,7 +41,6 @@ teams:
       - lei-tang
       - lgadban
       - linsun
-      - lizan
       - louiscryan
       - Monkeyanator
       - MorrisLaw
@@ -53,12 +50,9 @@ teams:
       - pmerrison
       - ramaraochavali
       - rcernich
-      - richardwxn
       - rootsongjc
       - rvennam
-      - shankgan
       - stevenctl
-      - stewartbutler
       - therealmitchconnors
       - wilsonwu
       - windsonsea
@@ -73,13 +67,11 @@ teams:
         members:
           - dhawton
           - howardjohn
-          - stewartbutler
       WG - Docs Maintainers:
         description: Maintainers of the Docs working group.
         members:
           - bleggett
           - craigbox
-          - davidhauck
           - dhawton
           - ericvn
           - frankbu
@@ -129,7 +121,6 @@ teams:
             members:
               - bleggett
               - craigbox
-              - davidhauck
               - dhawton
               - ericvn
               - frankbu
@@ -152,13 +143,11 @@ teams:
           - Monkeyanator
           - nmittler
           - rcernich
-          - richardwxn
           - stevenctl
           - zirain
       WG - Networking Maintainers:
         description: Maintainers for the Networking working group
         members:
-          - adiprerepa
           - bleggett
           - costinm
           - GregHanson
@@ -169,7 +158,6 @@ teams:
           - keithmattix
           - kyessenov
           - linsun
-          - lizan
           - nmittler
           - nrjpoddar
           - ramaraochavali
@@ -178,7 +166,6 @@ teams:
           WG - Networking Maintainers/Pilot:
             description: Maintainers of particular parts of Pilot.
             members:
-              - adiprerepa
               - costinm
               - howardjohn
               - hzxuzhonghu
@@ -219,7 +206,6 @@ teams:
           - linsun
           - nrjpoddar
           - pmerrison
-          - shankgan
       WG - Security Maintainers:
         description: Maintainers for the Security working group
         members:
@@ -230,8 +216,6 @@ teams:
           - irisdingbj
           - jaellio
           - lei-tang
-          - lizan
-          - shankgan
       WG - Test and Release Maintainers:
         description: Maintainers for the Test and Release working group.
         members:
@@ -244,9 +228,7 @@ teams:
           - kfaseela
           - linsun
           - nmittler
-          - richardwxn
           - stevenctl
-          - stewartbutler
           - therealmitchconnors
       WG - User Experience Maintainers:
         description: Maintainers for the User Experience working group.
@@ -351,7 +333,6 @@ teams:
       - jaellio # PSWG
       - justinpettit # PSWG
       - lei-tang # Security, E&T
-      - lizan # Data Plane, Security
       - ramaraochavali # Control Plane
       - stevenctl # Control Plane
       - therealmitchconnors # UX


### PR DESCRIPTION
This PR moves maintainers who appear to be inactive in the project to Emeritus.

> If a maintainer becomes inactive in the project for over a year, the individual will be asked to transition to an emeritus maintainer. Emeritus maintainers lose their ability to approve code contributions, but retain their voting rights for up to one year. After one year, emeritus maintainers revert back to being normal members with no voting rights.

This has a few motivations:

* Thank and honor all the past maintainers for all the invaluable work they have done over the years
* Trim the list of maintainers to (1) improve discover-ability of who is able to actively maintainer/review/etc an area and (2) reduce the number of privileged users in the org

This list was compiled by examining maintainers activity (PRs, issues, comments, etc) over the past year.  This list is those who appear to no longer be involved; another PR will follow with members who are present but have low activity.

The goal here is very much not to "kick people out" of the maintainers list. If you feel you are interested in continuing your maintainer role, simply comment here (or DM me) and I will update the PR.  Given it's close to the holiday period I will keep this open until mid-January or until I've heard from everyone on the list. However, one note: you do not need to hold a formal title of "maintainer" to be a valuable contributor to the project, and if you do step down the process to step back into the role when you have more time to commit to Istio is fairly quick and easy.

Tagging impacted members: @stewartbutler, @davidhauck, @richardwxn, @adiprerepa, @lizan, @shankgan

Thanks again for all your contributions!

Past PRs: #817 (2022), #1322 (2023)