### PR TITLE
Add Stevenjin8 as networking maintainer

### DIFF
--- a/org/teams.yaml
+++ b/org/teams.yaml
@@ -174,6 +174,7 @@ teams:
           - nrjpoddar
           - ramaraochavali
           - stevenctl
+          - Stevenjin8
         teams:
           WG - Networking Maintainers/Pilot:
             description: Maintainers of particular parts of Pilot.
@@ -193,7 +194,7 @@ teams:
               - hzxuzhonghu
               - ilrudie
               - stevenctl
-      WG - Policies and Telemetry  Maintainers:
+      WG - Policies and Telemetry Maintainers:
         description: Maintainers for the Policy and Telemetry working group.
         members:
           - keithmattix

--- a/org/teams.yaml
+++ b/org/teams.yaml
@@ -58,6 +58,7 @@ teams:
       - rvennam
       - shankgan
       - stevenctl
+      - Stevenjin8
       - stewartbutler
       - therealmitchconnors
       - wilsonwu


### PR DESCRIPTION
Hey Folks,

Been contributing for a while and am looking to get maintainership for the networking group. Here are contributions I've made:

* https://github.com/istio/ztunnel/pull/615 This PR decreased latency for simple request/reponse HTTP requests by over 40x
* https://github.com/istio/istio/pull/53623  https://github.com/envoyproxy/envoy/pull/35745 Worked across Istio and Envoy to add jitter to DNS resolution to avoid overloading DNS servers
* https://github.com/istio/ztunnel/pull/1283 Added coverage to Ztunnel CI
* Currently, I am working on implementing double HBONE for the ambient multicluster effort https://github.com/istio/ztunnel/pull/1429.

There are more across [Istio](https://github.com/pulls?q=is%3Apr+author%3AStevenjin8+archived%3Afalse+org%3Aistio) and [Envoy](https://github.com/pulls?q=is%3Apr+author%3AStevenjin8+archived%3Afalse+org%3Aenvoyproxy).

I've also been active on Slack and Github issues.

- [x] I have reviewed the [community membership guidelines](https://github.com/istio/community/blob/master/ROLES.md#member)
- [x] I have reviewed the [contribution guidelines](https://github.com/istio/community/blob/master/CONTRIBUTING.md)
- [x] I have enabled [2FA on my GitHub account](https://github.com/settings/security)
- [x] I have joined [Istio's Slack workspace](https://slack.istio.io)
- [x] I have written my company name or "Individual", if not affliated with a company, here: Microsoft
- [x] I have provided a link to at least one PR that I have successfully pushed to one of the Istio repos, here: __________
