### PR TITLE
extend Steering election by 1 week

### DIFF
--- a/steering/elections/2025/README.md
+++ b/steering/elections/2025/README.md
@@ -19,10 +19,12 @@ Some direct responsibilities of steering members to consider as you are deciding
 | Date               | Event                                                               |
 |--------------------|---------------------------------------------------------------------|
 | February 12        | Announcement of Election and publication of voters.yaml             |
-| February 23        | Candidate bios and voting exception forms due by 2359 UTC (5pm PDT) |
-| February 24        | Election begins via Elekto UI                                       |
-| March 9            | Election closes at 2359 UTC (5pm PDT)                               |
-| week of March 10   | Winners announced                                                   |
+| March 2 †          | Candidate bios and voting exception forms due by 2359 UTC (5pm PDT) |
+| March 3            | Election begins via Elekto UI                                       |
+| March 16           | Election closes at 2359 UTC (5pm PDT)                               |
+| week of March 17   | Winners announced                                                   |
+
+_† Please note an extra week has been added to the originally announced schedule._
 
 ## Candidacy process
 

--- a/steering/elections/2025/election.yaml
+++ b/steering/elections/2025/election.yaml
@@ -1,7 +1,7 @@
 name: 2025 Steering Committee Election
 organization: Istio
-start_datetime: 2025-02-24 00:00:01
-end_datetime: 2025-03-09 11:59:59
+start_datetime: 2025-03-03 00:00:01
+end_datetime: 2025-03-16 11:59:59
 no_winners: 4
 allow_no_opinion: True
 delete_after: True
@@ -13,4 +13,4 @@ election_officers:
   - craigbox
 eligibility: A [project member](https://github.com/istio/community/blob/master/ROLES.md#member) who has had at least one Pull Request merged in the past 12 months. See [the election guide](https://github.com/istio/community/tree/master/steering/elections/2025)
 exception_description: People who have demonstrated contribution to the Istio project that is of a non-code nature in the 12 months prior to the election can be granted a vote for the election by a simple majority vote of the Steering Committee.
-exception_due: 2025-02-23 11:59:59
+exception_due: 2025-03-02 11:59:59


### PR DESCRIPTION
As of close of play, we had 2 candidates standing; a 3rd was submitted ~6 hours after the deadline.

We know we have another couple of potential candidates, and we also know that we are busy with the 1.25 release.  Given this, we are extending the election nomination period by one week.