### PR TITLE
add dependabot to members

### DIFF
--- a/org/members.yaml
+++ b/org/members.yaml
@@ -99,8 +99,8 @@ members:
 - davidraskin
 - dcberg
 - dddddai
-- dependabot
 - delavet
+- dependabot
 - deszhou
 - deveshkandpal1224
 - devincd

--- a/org/members.yaml
+++ b/org/members.yaml
@@ -99,6 +99,7 @@ members:
 - davidraskin
 - dcberg
 - dddddai
+- dependabot
 - delavet
 - deszhou
 - deveshkandpal1224


### PR DESCRIPTION
make [dependabot](http://github.com/dependabot) a member so we don't have to ack CI on its PRs.