### PR TITLE
Revert "add dependabot to members"

### DIFF
--- a/org/members.yaml
+++ b/org/members.yaml
@@ -100,7 +100,6 @@ members:
 - dcberg
 - dddddai
 - delavet
-- dependabot
 - deszhou
 - deveshkandpal1224
 - devincd


### PR DESCRIPTION
Reverts istio/community#1571

I don't know how to do this, but it doesn't work. Pretty sure dependabot won't join our org; we would need a prow-level config not a github level config. I am not sure if prow has a config to do so.

This breaks the postsubmit job