### PR TITLE
nominate Pratima Nambiar to Steering

### DIFF
--- a/steering/elections/2025/candidate-pnambiarsf.md
+++ b/steering/elections/2025/candidate-pnambiarsf.md
@@ -1,0 +1,15 @@
+-------------------------------------------------------------
+name: Pratima Nambiar
+ID: pnambiarsf
+info:
+  - employer: Salesforce
+  - slack: Pratima Nambiar
+-------------------------------------------------------------
+
+### About me
+
+Pratima is the Lead Architect for the Hyperforce Infrastructure Platform, built on public cloud. She leads the teams that build and operate Service Mesh and Ingress Gateway for a large part of Salesforce.
+
+### Why I'm running
+
+We use Istio at Salesforce, and I would like to contribute to its continued success and shaping its direction.   


### PR DESCRIPTION
Pratima was a Steering member from 2020-2022, holding Salesforce's Contribution Seat.  She was an active and useful member of the group and, with her consent, I am pleased to nominate her for a Community Seat.
