### PR TITLE
fix makefile lint target error 

### DIFF
--- a/Makefile.core.mk
+++ b/Makefile.core.mk
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 # lint can  run all lint-all targets minus lint-markdown which is run by the community-lint.sh
-lint: lint-dockerfiles lint-scripts lint-yaml lint-helm lint-copyright-banner lint-go lint-python lint-sass lint-typescript lint-protos lint-licenses
+lint: lint-dockerfiles lint-scripts lint-yaml lint-helm lint-copyright-banner lint-go lint-python lint-sass lint-typescript lint-licenses
 	@prow/community-lint.sh
 
 test:


### PR DESCRIPTION
Running make lint in this repo results in the following error:
```
make[1]: *** No rule to make target 'lint-protos', needed by 'lint'.  Stop.
make: *** [Makefile:44: lint] Error 2
```
Since there is no `lint-protos` target defined in the [common Makefile](https://github.com/istio/community/blob/master/common/Makefile.common.mk), and this repo does not use protos, I removed the lint-protos dependency from the Makefile.
