### PR TITLE
Nominate Steven Jin Xuan for Networking Maintainer

### DIFF
--- a/org/teams.yaml
+++ b/org/teams.yaml
@@ -154,7 +154,7 @@ teams:
           - linsun
           - ramaraochavali
           - stevenctl
-          - stevenjin8
+          - Stevenjin8
           - zirain
         teams:
           WG - Networking Maintainers/Pilot:


### PR DESCRIPTION
I want to nominate Steven Jin Xuan as a networking maintainer. During his time with the Istio project, he's been active in both [reviewing](https://github.com/search?q=repo%3Aistio%2Fistio%20involves%3Astevenjin8%20is%3Apr&type=pullrequests) and [authoring](https://github.com/search?q=repo%3Aistio%2Fistio+author%3Astevenjin8+is%3Apr&type=pullrequests) PRs, and I believe he would be an excellent networking maintainer. Here are some specific PRs and reviews in the networking area:
1. istio/istio#57716
2. istio/istio#56982
3. istio/istio#56844
4. https://github.com/istio/istio/pull/57729#issuecomment-3319591086
5. https://github.com/istio/istio/pull/57707#issuecomment-3312295065
6. https://github.com/istio/istio/pull/57696#discussion_r2416986423

Opening this up to @istio/technical-oversight-committee @istio/wg-networking-maintainers for comment