### PR TITLE
add keith to docs infra team

### DIFF
--- a/org/teams.yaml
+++ b/org/teams.yaml
@@ -113,6 +113,7 @@ teams:
               - craigbox
               - dhawton
               - ericvn
+              - keithmattix
               - kfaseela
           WG - Docs Maintainers/Portuguese:
             description: Maintainers of the Portuguese documentation


### PR DESCRIPTION
We're running a little short on maintainers here. Keith is already a docs maintainer, gives another set of eyes to the infra side.