### PR TITLE
remove stale accounts breaking org sync

### DIFF
--- a/org/members.yaml
+++ b/org/members.yaml
@@ -565,7 +565,6 @@ members:
 - zachgersh
 - ZackButcher
 - zackzhangkai
-- zaunist
 - zc2638
 - zcahana
 - zehuaiWANG

--- a/org/teams.yaml
+++ b/org/teams.yaml
@@ -135,7 +135,6 @@ teams:
           - hzxuzhonghu
           - ilrudie
           - keithmattix
-          - kyessenov
           - linsun
           - ramaraochavali
           - sridhargaddam


### PR DESCRIPTION
sync-org postsubmit has failed on every run since apr 20: zaunist github account no longer exists (404 on add) and kyessenov team add returns 403, either aborts the whole peribolos run so no team changes sync. removes zaunist from members and kyessenov from wg-networking maintainers so the sync can converge.