### PR TITLE
sync steering committee team with steering/README.md

### DIFF
--- a/org/members.yaml
+++ b/org/members.yaml
@@ -204,6 +204,7 @@ members:
 - istio-policy-bot
 - istio-release-robot
 - istio-testing
+- jack4it
 - jackkleeman
 - jacob-delgado
 - jaellio

--- a/org/teams.yaml
+++ b/org/teams.yaml
@@ -281,15 +281,15 @@ teams:
       - craigbox
       - howardjohn
       - hzxuzhonghu
-      - ilevine
-      - justinpettit
+      - jack4it
+      - jaellio
       - keithmattix
       - kfaseela
       - linsun
       - louiscryan
-      - louiscryan
       - rcernich
-      - wilsonwu
+      - Stevenjin8
+      - tjons
       - ZackButcher
     repos:
       .default: write


### PR DESCRIPTION
org/teams.yaml steering list was never updated for the may election changes (#1757, #1758 only touched the README). adds Stevenjin8, jack4it, jaellio, tjons, removes ilevine, justinpettit, wilsonwu, dedups louiscryan. also adds jack4it to members.yaml since he wasn't an org member yet.