### PR TITLE
removing zachgersh account from members

### DIFF
--- a/org/members.yaml
+++ b/org/members.yaml
@@ -564,7 +564,6 @@ members:
 - yxxhero
 - yyyhhhh
 - yyzxw
-- zachgersh
 - ZackButcher
 - zackzhangkai
 - zc2638


### PR DESCRIPTION
We are getting some error while running the sync with the user account zachgersh, the account seems to have a sort of restriction and cause the sync to fail, for example: https://aws.prow.istio.io/view/s3/istio-prow/logs/sync-org_community_postsubmit/2092982223127973888
