### PR TITLE
remove and add psb to sync org

### DIFF
--- a/org/members.yaml
+++ b/org/members.yaml
@@ -389,7 +389,6 @@ members:
 - pnambiarsf
 - potsju
 - prashanthjos
-- psbrar99
 - Purushotham233
 - qfel
 - quanjielin

--- a/org/teams.yaml
+++ b/org/teams.yaml
@@ -46,7 +46,6 @@ teams:
       - my-git9
       - PetrMc
       - pmerrison
-      - psbrar99
       - ramaraochavali
       - rcernich
       - sridhargaddam
@@ -191,7 +190,6 @@ teams:
           - mkralik3
           - PetrMc
           - pmerrison
-          - psbrar99
           - Stevenjin8
           - yannuil
       WG - Security Maintainers:


### PR DESCRIPTION
<!-- Is this PR to join the Istio org?  If so, please fill in the below.  If not, delete everything before continuing. -->

removing and adding myself back so that org pipeline sync succeeds.
 
 the pipleline was failing because of invalid gh handle of a particular user https://github.com/istio/community/pull/1783, it was fixed after merging my pr.
 
## I want to join the Istio org!

- [ ] I have reviewed the [community membership guidelines](https://github.com/istio/community/blob/master/ROLES.md#member)
- [ ] I have reviewed the [contribution guidelines](https://github.com/istio/community/blob/master/CONTRIBUTING.md)
- [ ] I have enabled [2FA on my GitHub account](https://github.com/settings/security)
- [ ] I have joined [Istio's Slack workspace](https://slack.istio.io)
- [ ] I have written my company name or "Individual", if not affliated with a company, here: __________
- [ ] I have provided a link to at least one PR that I have successfully pushed to one of the Istio repos, here: __________
